### PR TITLE
Feat: 인증/인가 api 명세서 구현

### DIFF
--- a/src/main/java/com/knu/algo_hive/auth/controller/AuthRestController.java
+++ b/src/main/java/com/knu/algo_hive/auth/controller/AuthRestController.java
@@ -1,0 +1,69 @@
+package com.knu.algo_hive.auth.controller;
+
+import com.knu.algo_hive.auth.dto.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/auth")
+@Tag(name = "인증/인가 기능", description = "회원 인증 및 인가 기능을 위한 api")
+public class AuthRestController {
+    @Operation(summary = "회원 가입 기능(미구현)",
+            description = "닉네임, 이메일, 비밀번호를 입력받아 회원가입을 진행한다.",
+            security = @SecurityRequirement(name = "Session 제외"))
+    @PostMapping("/register")
+    public String register(@RequestBody RegisterRequest registerRequest){
+
+        return "성공";
+    }
+
+    @Operation(summary = "로그인 기능(미구현)",
+            description = "이메일, 비밀번호를 입력받아 로그인을 진행한다.",
+            security = @SecurityRequirement(name = "Session 제외"))
+    @PostMapping("/login")
+    public String login(@RequestBody LoginRequest loginRequest){
+
+        return "성공";
+    }
+
+    @Operation(summary = "이메일 인증 기능 - 인증번호 발급(미구현)",
+            description = "이메일을 입력받아 인증번호를 생성한다.",
+            security = @SecurityRequirement(name = "Session 제외"))
+    @PostMapping("/code")
+    public String sendVerificationCode(@RequestBody EmailRequest emailRequest){
+
+        return "성공";
+    }
+
+    @Operation(summary = "이메일 인증 기능 - 인증번호 확인(미구현)",
+            description = "이메일과 인증번호를 입력받아 인증번호를 확인한다.",
+            security = @SecurityRequirement(name = "Session 제외"))
+    @PostMapping("/verify")
+    public String verifyEmail(@RequestBody VerificationRequest verificationRequest){
+
+        return "성공";
+    }
+
+    @Operation(summary = "닉네임 중복 확인(미구현)",
+            description = "닉네임이 다른 사용자와 중복되는지 확인한다.",
+            security = @SecurityRequirement(name = "Session 제외"))
+    @PostMapping("/nick-name")
+    public String checkNickName(@RequestBody NickNameRequest nickNameRequest){
+
+        return "성공";
+    }
+
+    @Operation(summary = "이메일 중복 확인(미구현)",
+            description = "이메일이 다른 사용자와 중복되는지 확인한다.",
+            security = @SecurityRequirement(name = "Session 제외"))
+    @PostMapping("/email")
+    public String checkEmail(@RequestBody EmailRequest emailRequest){
+
+        return "성공";
+    }
+}

--- a/src/main/java/com/knu/algo_hive/auth/dto/EmailRequest.java
+++ b/src/main/java/com/knu/algo_hive/auth/dto/EmailRequest.java
@@ -1,0 +1,4 @@
+package com.knu.algo_hive.auth.dto;
+
+public record EmailRequest(String email) {
+}

--- a/src/main/java/com/knu/algo_hive/auth/dto/LoginRequest.java
+++ b/src/main/java/com/knu/algo_hive/auth/dto/LoginRequest.java
@@ -1,0 +1,4 @@
+package com.knu.algo_hive.auth.dto;
+
+public record LoginRequest(String email, String password) {
+}

--- a/src/main/java/com/knu/algo_hive/auth/dto/NickNameRequest.java
+++ b/src/main/java/com/knu/algo_hive/auth/dto/NickNameRequest.java
@@ -1,0 +1,4 @@
+package com.knu.algo_hive.auth.dto;
+
+public record NickNameRequest(String nickName) {
+}

--- a/src/main/java/com/knu/algo_hive/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/knu/algo_hive/auth/dto/RegisterRequest.java
@@ -1,0 +1,4 @@
+package com.knu.algo_hive.auth.dto;
+
+public record RegisterRequest(String nickName, String email, String password) {
+}

--- a/src/main/java/com/knu/algo_hive/auth/dto/VerificationRequest.java
+++ b/src/main/java/com/knu/algo_hive/auth/dto/VerificationRequest.java
@@ -1,0 +1,4 @@
+package com.knu.algo_hive.auth.dto;
+
+public record VerificationRequest(String email, String code) {
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #9 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

- 인증 및 인가 기능을 위한 컨트롤러 클래스 및 request 추가하였습니다.
- Swagger의 명세서를 나타내기 위해 컨트롤러와 RequestBody만 추가하였으며, 현재 서비스 기능은 아직 추가하지 않았습니다.
- 로컬 화면에서는 정상적으로 추가된 것 확인했습니다.
![image](https://github.com/user-attachments/assets/46af2526-0d40-4a82-b2ef-7fdafc6dc731)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

> DTO의 Request 중 email이나 nickName 변수 하나만 들어가있는 경우가 있는데, 이런 경우에는 그냥 RequestBody에 String email 이런 식으로 별도의 Request 클래스를 생성해야할 지 고민입니다. 뭔가 통일성을 위해 클래스가 더 생겨나는 느낌이라... 어떻게 해야할 지 잘 모르겠습니다.


## ⏰ 현재 버그
