### PR TITLE
Feat: 게시물, 좋아요, 댓글, 태그 Swagger 명세

### DIFF
--- a/src/main/java/com/knu/algo_hive/post/controller/CommentController.java
+++ b/src/main/java/com/knu/algo_hive/post/controller/CommentController.java
@@ -1,0 +1,68 @@
+package com.knu.algo_hive.post.controller;
+
+import com.knu.algo_hive.post.dto.CommentResponse;
+import com.knu.algo_hive.post.dto.CommentRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@Tag(name = "게시물_댓글", description = "게시물의 댓글 관련 API")
+public class CommentController {
+
+    @GetMapping("/api/v1/posts/{postId}/comments")
+    @Operation(summary = "특정 게시물의 댓글 페이지네이션 조회(미구현)",
+            description = "페이지네이션 적용. /api/v1/posts/{postId}/comments?page={page번호}&size={page content 개수}&sort={content 속성},{desc || asc} ✅ex) 생성일 기준 내림차순 조회(최신 댓글 부터) /api/v1/posts/{postId}/comments?page=0&size=10&sort=createdAt,desc"
+
+    )
+    @Parameters({
+            @Parameter(in = ParameterIn.QUERY, name = "page", description = "페이지 번호 (0부터 시작)", example = "0", schema = @Schema(type = "integer", defaultValue = "0")),
+            @Parameter(in = ParameterIn.QUERY, name = "size", description = "페이지 크기", example = "10", schema = @Schema(type = "integer", defaultValue = "10")),
+            @Parameter(in = ParameterIn.QUERY, name = "sort", description = "정렬 기준 (속성,오름차순|내림차순)", example = "createdAt,desc", schema = @Schema(type = "string"))
+    })
+    public ResponseEntity<Page<CommentResponse>> getComments(@PathVariable Long postId) {
+
+        CommentResponse comment1 = new CommentResponse(0L, "좋은데여? 굳", LocalDateTime.now().minusDays(4), LocalDateTime.now().minusDays(4), "물통");
+        CommentResponse comment2 = new CommentResponse(0L, "별로임...", LocalDateTime.now().minusDays(4), LocalDateTime.now().minusDays(4), "물병");
+        List<CommentResponse> posts = List.of(comment1, comment2);
+        Page<CommentResponse> page = new PageImpl<>(posts, PageRequest.of(0, 5), 2);
+        return ResponseEntity.ok(page);
+    }
+
+    @PostMapping("/api/v1/posts/{postId}/comments")
+    @Operation(summary = "댓글 저장 (미구현)",
+            description = "댓글 달기"
+    )
+    public ResponseEntity<Void> saveComment(@RequestBody CommentRequest request,
+                                            @PathVariable Long postId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/api/v1/posts/{postId}/comments")
+    @Operation(summary = "댓글 수정 (미구현)",
+            description = "댓글 수정하기"
+    )
+    public ResponseEntity<Void> updateComment(@RequestBody CommentRequest request,
+                                              @PathVariable Long postId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/api/v1/posts/{postId}/comments")
+    @Operation(summary = "댓글 삭제 (미구현)",
+            description = "댓글 삭제하기"
+    )
+    public ResponseEntity<Void> deleteComment(@PathVariable Long postId) {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/knu/algo_hive/post/controller/LikeController.java
+++ b/src/main/java/com/knu/algo_hive/post/controller/LikeController.java
@@ -1,0 +1,41 @@
+package com.knu.algo_hive.post.controller;
+
+import com.knu.algo_hive.post.dto.LikeCountResponse;
+import com.knu.algo_hive.post.dto.LikeStatusResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "게시물_좋아요", description = "게시물의 좋아요 관련 API")
+public class LikeController {
+
+    @GetMapping("/api/v1/posts/{postId}/likes/count")
+    @Operation(summary = "좋아요 개수 조회(미구현)",
+            description = "좋아요 개수 조회"
+    )
+    public ResponseEntity<LikeCountResponse> getLikeCount(@PathVariable String postId) {
+        LikeCountResponse likeCountResponse = new LikeCountResponse(34);
+        return ResponseEntity.ok(likeCountResponse);
+    }
+
+    @PutMapping("/api/v1/posts/{postId}/likes/status")
+    @Operation(summary = "좋아요 상태 변경(좋아요/좋아요 취소) (미구현)",
+            description = "좋아요 상태 변경. api 요청마다 상태가 반전됨. 200 응답시 현 좋아요 상태 반환"
+    )
+    public ResponseEntity<LikeStatusResponse> changeLikeStatus(@PathVariable String postId) {
+        return ResponseEntity.ok(new LikeStatusResponse(true));
+    }
+
+    @GetMapping("/api/v1/posts/{postId}/likes/status")
+    @Operation(summary = " 좋아요 상태 조회 (미구현)",
+            description = "현재 유저의 해당 포스트 좋아요 상태 조회. 200 응답시 현 좋아요 상태 반환"
+    )
+    public ResponseEntity<LikeStatusResponse> getLikeStatus(@PathVariable Long postId) {
+        return ResponseEntity.ok(new LikeStatusResponse(true));
+    }
+}

--- a/src/main/java/com/knu/algo_hive/post/controller/PostController.java
+++ b/src/main/java/com/knu/algo_hive/post/controller/PostController.java
@@ -1,0 +1,143 @@
+package com.knu.algo_hive.post.controller;
+
+import com.knu.algo_hive.post.dto.PostResponse;
+import com.knu.algo_hive.post.dto.PostSaveRequest;
+import com.knu.algo_hive.post.dto.PostSummaryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@Tag(name = "게시물_CRUD", description = "게시물 관련 API")
+public class PostController {
+    @GetMapping("/api/v1/posts")
+    @Operation(summary = "모든 게시물 페이지네이션 조회(미구현)",
+            description = "페이지네이션 적용. /api/v1/posts/all?page={page번호}&size={page content 개수}&sort={content 속성},{desc || asc} ✅ex)좋아요 개수 기준 내림차순 조회 /api/v1/posts/all?page=0&size=10&sort=likeCount,desc"
+    )
+    @Parameters({
+            @Parameter(in = ParameterIn.QUERY, name = "page", description = "페이지 번호 (0부터 시작)", example = "0", schema = @Schema(type = "integer", defaultValue = "0")),
+            @Parameter(in = ParameterIn.QUERY, name = "size", description = "페이지 크기", example = "10", schema = @Schema(type = "integer", defaultValue = "10")),
+            @Parameter(in = ParameterIn.QUERY, name = "sort", description = "정렬 기준 (속성,오름차순|내림차순)", example = "createdAt,desc", schema = @Schema(type = "string"))
+    })
+    public ResponseEntity<Page<PostSummaryResponse>> getPostSummaries(@Parameter(hidden = true)
+                                                                      @PageableDefault(size = 10, sort = "createdAt,desc")
+                                                                      Pageable pageable) {
+        PostSummaryResponse post1 = new PostSummaryResponse(1L, "굉장한 제목", "https://cdn.pixabay.com/photo/2024/02/12/21/34/sunset-8569636_1280.jpg", "요약!", LocalDateTime.now(), 777, 777, "김계란");
+        PostSummaryResponse post2 = new PostSummaryResponse(0L, "이상한 제목", "https://cdn.pixabay.com/photo/2024/02/12/21/34/sunset-8569636_1280.jpg", "요약~", LocalDateTime.now().minusDays(3), 3, 53, "김김");
+        List<PostSummaryResponse> posts = List.of(post1, post2);
+        Page<PostSummaryResponse> page = new PageImpl<>(posts, PageRequest.of(0, 5), 2);
+        return ResponseEntity.ok(page);
+    }
+
+    @GetMapping("/api/v1/{nickname}/posts")
+    @Operation(summary = "특정 유저의 게시물 페이지네이션 조회(미구현)",
+            description = "페이지네이션 적용. /api/v1/posts?page={page번호}&size={page content 개수}&sort={content 속성},{desc || asc} ✅ex)좋아요 개수 기준 내림차순 조회 /api/v1/posts?page=0&size=10&sort=likeCount,desc"
+
+    )
+    @Parameters({
+            @Parameter(in = ParameterIn.QUERY, name = "page", description = "페이지 번호 (0부터 시작)", example = "0", schema = @Schema(type = "integer", defaultValue = "0")),
+            @Parameter(in = ParameterIn.QUERY, name = "size", description = "페이지 크기", example = "10", schema = @Schema(type = "integer", defaultValue = "10")),
+            @Parameter(in = ParameterIn.QUERY, name = "sort", description = "정렬 기준 (속성,오름차순|내림차순)", example = "createdAt,desc", schema = @Schema(type = "string"))
+    })
+    public ResponseEntity<Page<PostSummaryResponse>> getMyPostSummaries(@Parameter(hidden = true)
+                                                                        @PageableDefault(size = 10, sort = "createdAt,desc")
+                                                                        Pageable pageable,
+                                                                        @PathVariable String nickname) {
+        PostSummaryResponse post1 = new PostSummaryResponse(1L, "굉장한 제목", "https://cdn.pixabay.com/photo/2024/02/12/21/34/sunset-8569636_1280.jpg", "요약!", LocalDateTime.now(), 777, 777, "아무개");
+        PostSummaryResponse post2 = new PostSummaryResponse(0L, "이상한 제목", "https://cdn.pixabay.com/photo/2024/02/12/21/34/sunset-8569636_1280.jpg", "요약~", LocalDateTime.now().minusDays(3), 3, 53, "홍길동");
+        List<PostSummaryResponse> posts = List.of(post1, post2);
+        Page<PostSummaryResponse> page = new PageImpl<>(posts, PageRequest.of(0, 5), 2);
+        return ResponseEntity.ok(page);
+    }
+
+    @GetMapping("/api/v1/posts/{postId}")
+    @Operation(summary = "게시물 상세 조회(미구현)",
+            description = "게시물 상세 조회"
+    )
+    public ResponseEntity<PostResponse> getPost(@PathVariable Long postId) {
+        PostResponse postResponse = new PostResponse(0L, "굉장한 제목", "Hello 방가", "https://cdn.pixabay.com/photo/2024/02/12/21/34/sunset-8569636_1280.jpg", "요약!", 777, 777, LocalDateTime.now(), LocalDateTime.now(), "JAMES");
+        return ResponseEntity.ok(postResponse);
+    }
+
+    @PostMapping("/api/v1/posts")
+    @Operation(summary = "게시물 저장(미구현)",
+            description = "게시물 저장"
+    )
+    public ResponseEntity<Void> savePost(@RequestBody PostSaveRequest request) {
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/api/v1/posts/{postId}")
+    @Operation(summary = "게시물 수정(미구현)",
+            description = "게시물 수정"
+    )
+    public ResponseEntity<Void> updatePost(@PathVariable Long postId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/api/v1/posts/{postId}")
+    @Operation(summary = "게시물 삭제(미구현)",
+            description = "게시물 삭제"
+    )
+    public ResponseEntity<Void> deletePost(@PathVariable Long postId) {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/v1/posts/tags/{tagName}")
+    @Operation(summary = " 태그별로 모든 게시물 페이지네이션 조회(미구현)",
+            description = "페이지네이션 적용. /api/v1/posts?page={page번호}&size={page content 개수}&sort={content 속성},{desc || asc} ✅ex)좋아요 개수 기준 내림차순 조회 /api/v1/posts?page=0&size=10&sort=likeCount,desc"
+
+    )
+    @Parameters({
+            @Parameter(in = ParameterIn.QUERY, name = "page", description = "페이지 번호 (0부터 시작)", example = "0", schema = @Schema(type = "integer", defaultValue = "0")),
+            @Parameter(in = ParameterIn.QUERY, name = "size", description = "페이지 크기", example = "10", schema = @Schema(type = "integer", defaultValue = "10")),
+            @Parameter(in = ParameterIn.QUERY, name = "sort", description = "정렬 기준 (속성,오름차순|내림차순)", example = "createdAt,desc", schema = @Schema(type = "string"))
+    })
+    public ResponseEntity<Page<PostSummaryResponse>> getAllPostSummariesByTag(@Parameter(hidden = true)
+                                                                              @PageableDefault(size = 10, sort = "createdAt,desc")
+                                                                              @PathVariable String tagName,
+                                                                              Pageable pageable) {
+
+        PostSummaryResponse post1 = new PostSummaryResponse(1L, "굉장한 제목", "https://cdn.pixabay.com/photo/2024/02/12/21/34/sunset-8569636_1280.jpg", "요약!", LocalDateTime.now(), 777, 777, "이름이다");
+        PostSummaryResponse post2 = new PostSummaryResponse(0L, "이상한 제목", "https://cdn.pixabay.com/photo/2024/02/12/21/34/sunset-8569636_1280.jpg", "요약~", LocalDateTime.now().minusDays(3), 3, 53, "저자는 나");
+        List<PostSummaryResponse> posts = List.of(post1, post2);
+        Page<PostSummaryResponse> page = new PageImpl<>(posts, PageRequest.of(0, 5), 2);
+        return ResponseEntity.ok(page);
+    }
+
+    @GetMapping("/api/v1/{nickname}/posts/tags/{tagName}")
+    @Operation(summary = "특정 유저의 태그별 게시물 페이지네이션 조회(미구현)",
+            description = "페이지네이션 적용. /api/v1/posts?page={page번호}&size={page content 개수}&sort={content 속성},{desc || asc} ✅ex)좋아요 개수 기준 내림차순 조회 /api/v1/posts?page=0&size=10&sort=likeCount,desc"
+
+    )
+    @Parameters({
+            @Parameter(in = ParameterIn.QUERY, name = "page", description = "페이지 번호 (0부터 시작)", example = "0", schema = @Schema(type = "integer", defaultValue = "0")),
+            @Parameter(in = ParameterIn.QUERY, name = "size", description = "페이지 크기", example = "10", schema = @Schema(type = "integer", defaultValue = "10")),
+            @Parameter(in = ParameterIn.QUERY, name = "sort", description = "정렬 기준 (속성,오름차순|내림차순)", example = "createdAt,desc", schema = @Schema(type = "string"))
+    })
+    public ResponseEntity<Page<PostSummaryResponse>> getPostSummariesByTag(@Parameter(hidden = true)
+                                                                           @PageableDefault(size = 10, sort = "createdAt,desc")
+                                                                           @PathVariable String tagName,
+                                                                           Pageable pageable,
+                                                                           @PathVariable String nickname) {
+
+        PostSummaryResponse post1 = new PostSummaryResponse(1L, "굉장한 제목", "https://cdn.pixabay.com/photo/2024/02/12/21/34/sunset-8569636_1280.jpg", "요약!", LocalDateTime.now(), 777, 777, "방가");
+        PostSummaryResponse post2 = new PostSummaryResponse(0L, "이상한 제목", "https://cdn.pixabay.com/photo/2024/02/12/21/34/sunset-8569636_1280.jpg", "요약~", LocalDateTime.now().minusDays(3), 3, 53, "하하");
+        List<PostSummaryResponse> posts = List.of(post1, post2);
+        Page<PostSummaryResponse> page = new PageImpl<>(posts, PageRequest.of(0, 5), 2);
+        return ResponseEntity.ok(page);
+    }
+}

--- a/src/main/java/com/knu/algo_hive/post/controller/PostController.java
+++ b/src/main/java/com/knu/algo_hive/post/controller/PostController.java
@@ -1,7 +1,7 @@
 package com.knu.algo_hive.post.controller;
 
+import com.knu.algo_hive.post.dto.PostRequest;
 import com.knu.algo_hive.post.dto.PostResponse;
-import com.knu.algo_hive.post.dto.PostSaveRequest;
 import com.knu.algo_hive.post.dto.PostSummaryResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -76,7 +76,7 @@ public class PostController {
     @Operation(summary = "게시물 저장(미구현)",
             description = "게시물 저장"
     )
-    public ResponseEntity<Void> savePost(@RequestBody PostSaveRequest request) {
+    public ResponseEntity<Void> savePost(@RequestBody PostRequest request) {
         return ResponseEntity.ok().build();
     }
 
@@ -84,7 +84,8 @@ public class PostController {
     @Operation(summary = "게시물 수정(미구현)",
             description = "게시물 수정"
     )
-    public ResponseEntity<Void> updatePost(@PathVariable Long postId) {
+    public ResponseEntity<Void> updatePost(@PathVariable Long postId,
+                                           @RequestBody PostRequest request) {
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/knu/algo_hive/post/controller/TagController.java
+++ b/src/main/java/com/knu/algo_hive/post/controller/TagController.java
@@ -1,0 +1,43 @@
+package com.knu.algo_hive.post.controller;
+
+import com.knu.algo_hive.post.dto.TagRequest;
+import com.knu.algo_hive.post.dto.TagResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashSet;
+import java.util.List;
+
+@RestController
+@Tag(name = "게시물_태그", description = "게시물의 태그 관련 API")
+public class TagController {
+
+    @GetMapping("/api/v1/posts/{postId}/tags")
+    @Operation(summary = "게시물 태그 조회(미구현)",
+            description = "게시물 태그 조회"
+    )
+    public ResponseEntity<TagResponse> getTags(@PathVariable Long postId) {
+        TagResponse tagResponse = new TagResponse(new HashSet<String>(List.of("질문", "홍보", "취업")));
+        return ResponseEntity.ok(tagResponse);
+    }
+
+    @PostMapping("/api/v1/posts/{postId}/tags")
+    @Operation(summary = "게시물 태그 저장(미구현)",
+            description = "태그 저장"
+    )
+    public ResponseEntity<Void> addTags(@PathVariable Long postId,
+                                        @RequestBody TagRequest request) {
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/api/v1/posts/{postId}/tags")
+    @Operation(summary = "게시물 태그 수정(미구현)",
+            description = "태그 수정"
+    )
+    public ResponseEntity<Void> updateTags(@PathVariable Long postId,
+                                           @RequestBody TagRequest request) {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/knu/algo_hive/post/dto/CommentRequest.java
+++ b/src/main/java/com/knu/algo_hive/post/dto/CommentRequest.java
@@ -1,6 +1,9 @@
 package com.knu.algo_hive.post.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record CommentRequest(
+        @NotBlank
         String content
 ) {
 }

--- a/src/main/java/com/knu/algo_hive/post/dto/CommentRequest.java
+++ b/src/main/java/com/knu/algo_hive/post/dto/CommentRequest.java
@@ -1,0 +1,6 @@
+package com.knu.algo_hive.post.dto;
+
+public record CommentRequest(
+        String content
+) {
+}

--- a/src/main/java/com/knu/algo_hive/post/dto/CommentResponse.java
+++ b/src/main/java/com/knu/algo_hive/post/dto/CommentResponse.java
@@ -1,0 +1,12 @@
+package com.knu.algo_hive.post.dto;
+
+import java.time.LocalDateTime;
+
+public record CommentResponse(
+        Long id,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        String author
+) {
+}

--- a/src/main/java/com/knu/algo_hive/post/dto/LikeCountResponse.java
+++ b/src/main/java/com/knu/algo_hive/post/dto/LikeCountResponse.java
@@ -1,0 +1,6 @@
+package com.knu.algo_hive.post.dto;
+
+public record LikeCountResponse(
+        int likeCount
+) {
+}

--- a/src/main/java/com/knu/algo_hive/post/dto/LikeStatusResponse.java
+++ b/src/main/java/com/knu/algo_hive/post/dto/LikeStatusResponse.java
@@ -1,0 +1,6 @@
+package com.knu.algo_hive.post.dto;
+
+public record LikeStatusResponse(
+        boolean liked
+) {
+}

--- a/src/main/java/com/knu/algo_hive/post/dto/PostRequest.java
+++ b/src/main/java/com/knu/algo_hive/post/dto/PostRequest.java
@@ -3,7 +3,7 @@ package com.knu.algo_hive.post.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record PostSaveRequest(
+public record PostRequest(
         @NotBlank
         String title,
         @NotNull

--- a/src/main/java/com/knu/algo_hive/post/dto/PostResponse.java
+++ b/src/main/java/com/knu/algo_hive/post/dto/PostResponse.java
@@ -1,0 +1,17 @@
+package com.knu.algo_hive.post.dto;
+
+import java.time.LocalDateTime;
+
+public record PostResponse(
+        Long id,
+        String title,
+        String content,
+        String thumbnail,
+        String summary,
+        int likeCount,
+        int commentCount,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        String author
+) {
+}

--- a/src/main/java/com/knu/algo_hive/post/dto/PostSaveRequest.java
+++ b/src/main/java/com/knu/algo_hive/post/dto/PostSaveRequest.java
@@ -1,0 +1,18 @@
+package com.knu.algo_hive.post.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+public record PostSaveRequest(
+        @NotEmpty
+        @NotNull
+        String title,
+        @NotEmpty
+        @NotNull
+        String content,
+        @NotNull
+        String thumbnail,
+        @NotNull
+        String summary
+) {
+}

--- a/src/main/java/com/knu/algo_hive/post/dto/PostSaveRequest.java
+++ b/src/main/java/com/knu/algo_hive/post/dto/PostSaveRequest.java
@@ -1,13 +1,11 @@
 package com.knu.algo_hive.post.dto;
 
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record PostSaveRequest(
-        @NotEmpty
-        @NotNull
+        @NotBlank
         String title,
-        @NotEmpty
         @NotNull
         String content,
         @NotNull

--- a/src/main/java/com/knu/algo_hive/post/dto/PostSummaryResponse.java
+++ b/src/main/java/com/knu/algo_hive/post/dto/PostSummaryResponse.java
@@ -1,0 +1,15 @@
+package com.knu.algo_hive.post.dto;
+
+import java.time.LocalDateTime;
+
+public record PostSummaryResponse(
+        Long id,
+        String title,
+        String thumbnail,
+        String summary,
+        LocalDateTime createdAt,
+        int likeCount,
+        int commentCount,
+        String author
+) {
+}

--- a/src/main/java/com/knu/algo_hive/post/dto/TagRequest.java
+++ b/src/main/java/com/knu/algo_hive/post/dto/TagRequest.java
@@ -1,0 +1,8 @@
+package com.knu.algo_hive.post.dto;
+
+import java.util.Set;
+
+public record TagRequest(
+        Set<String> tags
+) {
+}

--- a/src/main/java/com/knu/algo_hive/post/dto/TagRequest.java
+++ b/src/main/java/com/knu/algo_hive/post/dto/TagRequest.java
@@ -1,8 +1,11 @@
 package com.knu.algo_hive.post.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 import java.util.Set;
 
 public record TagRequest(
+        @NotNull
         Set<String> tags
 ) {
 }

--- a/src/main/java/com/knu/algo_hive/post/dto/TagResponse.java
+++ b/src/main/java/com/knu/algo_hive/post/dto/TagResponse.java
@@ -1,0 +1,8 @@
+package com.knu.algo_hive.post.dto;
+
+import java.util.Set;
+
+public record TagResponse(
+        Set<String> tags
+) {
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#13 

## 📝 작업 내용


- 게시물, 좋아요, 댓글, 태그 Swagger 명세 우선 나오도록 하였습니다
### Swagger
![SCR-20250119-ljcw](https://github.com/user-attachments/assets/e421a517-60db-4495-872f-e5eb40d29f0e)
![SCR-20250119-ljfy](https://github.com/user-attachments/assets/5e86ccae-b2ca-45e3-ba34-75c18adee428)

### pagination 들 이렇게 명세 구성
![SCR-20250119-llhj](https://github.com/user-attachments/assets/5e520018-5649-427e-a0a7-db41ba82e89b)

### 설계
- 예상보다 생각할게 꽤 있더군요. 일단 이렇게 구성 예정이긴한데
![erd](https://github.com/user-attachments/assets/09d22681-4e25-4a50-97c7-a560c62edebe)
### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ⏰ 현재 버그

## ✏ Git Close

> close #이슈번호
> 
