### PR TITLE
Feat: 웹소켓을 이용한 채팅기능 구현

### DIFF
--- a/.github/ISSUE_TEMPLATE/algo-hive-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/algo-hive-issue-template.md
@@ -7,15 +7,6 @@ assignees: ''
 
 ---
 
----
-name: Sinitto issue template
-about: This is Sinitto issue template!
-title: ''
-labels: ''
-assignees: ''
-
----
-
 ## 🧐 어떤 기능인가요?
 
 > 추가하려는 기능에 대해 간결하게 설명해주세요.

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/knu/algo_hive/ai/controller/GeminiApiController.java
+++ b/src/main/java/com/knu/algo_hive/ai/controller/GeminiApiController.java
@@ -23,7 +23,7 @@ public class GeminiApiController {
     }
 
     @Operation(summary = "코드 기반 AI 분석 평가", description = "알고리즘 코드를 입력하면 Gemini AI를 활용하여 분석 결과를 velog 형식으로 리턴합니다.")
-    @PostMapping("/analyze")
+    @PostMapping("/v1/analyze")
     public ResponseEntity<GeminiApiResponse> analyzeCode(@RequestBody GeminiApiRequest geminiApiRequest) throws Exception {
         GeminiApiResponse geminiApiResponse = geminiApiService.analyzeCode(geminiApiRequest);
         return ResponseEntity.ok().body(geminiApiResponse);

--- a/src/main/java/com/knu/algo_hive/ai/controller/GeminiApiController.java
+++ b/src/main/java/com/knu/algo_hive/ai/controller/GeminiApiController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/ai")
+@RequestMapping("/api/v1/ai")
 @Tag(name = "AI", description = "코드 분석 및 블로그 글 작성 AI 관련 API")
 public class GeminiApiController {
 
@@ -23,7 +23,7 @@ public class GeminiApiController {
     }
 
     @Operation(summary = "코드 기반 AI 분석 평가", description = "알고리즘 코드를 입력하면 Gemini AI를 활용하여 분석 결과를 velog 형식으로 리턴합니다.")
-    @PostMapping("/v1/analyze")
+    @PostMapping("/analyze")
     public ResponseEntity<GeminiApiResponse> analyzeCode(@RequestBody GeminiApiRequest geminiApiRequest) throws Exception {
         GeminiApiResponse geminiApiResponse = geminiApiService.analyzeCode(geminiApiRequest);
         return ResponseEntity.ok().body(geminiApiResponse);

--- a/src/main/java/com/knu/algo_hive/ai/controller/GeminiApiController.java
+++ b/src/main/java/com/knu/algo_hive/ai/controller/GeminiApiController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/ai")
-@Tag(name = "AI", description = "코드 분석 및 블로그 글 작성 AI 관련 API")
+@Tag(name = "AI", description = "코드 분석 및 블로그 글 작성 AI 관련 api")
 public class GeminiApiController {
 
     private final GeminiApiService geminiApiService;
@@ -22,7 +22,7 @@ public class GeminiApiController {
         this.geminiApiService = geminiApiService;
     }
 
-    @Operation(summary = "코드 기반 AI 분석 평가", description = "알고리즘 코드를 입력하면 Gemini AI를 활용하여 분석 결과를 velog 형식으로 리턴합니다.")
+    @Operation(summary = "AI 기반 코드 분석 평가", description = "알고리즘 코드를 입력하면 Gemini AI를 활용하여 분석 결과를 velog 형식으로 리턴합니다.")
     @PostMapping("/analyze")
     public ResponseEntity<GeminiApiResponse> analyzeCode(@RequestBody GeminiApiRequest geminiApiRequest) throws Exception {
         GeminiApiResponse geminiApiResponse = geminiApiService.analyzeCode(geminiApiRequest);

--- a/src/main/java/com/knu/algo_hive/ai/controller/GeminiApiController.java
+++ b/src/main/java/com/knu/algo_hive/ai/controller/GeminiApiController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/ai")
-@Tag(name = "AI", description = "코드 분석 및 블로그 글 작성 AI 관련 api")
+@Tag(name = "AI", description = "코드 분석 및 블로그 글 작성 AI 관련 API")
 public class GeminiApiController {
 
     private final GeminiApiService geminiApiService;

--- a/src/main/java/com/knu/algo_hive/chat/entity/ChatMessage.java
+++ b/src/main/java/com/knu/algo_hive/chat/entity/ChatMessage.java
@@ -1,0 +1,34 @@
+package com.knu.algo_hive.chat.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String username;
+    @NotNull
+    private String message;
+    @NotNull
+    @CreatedDate
+    private LocalDateTime chatTime;
+
+    protected ChatMessage() {
+
+    }
+
+    public ChatMessage(String username, String message) {
+        this.username = username;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/knu/algo_hive/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/com/knu/algo_hive/chat/handler/ChatWebSocketHandler.java
@@ -1,0 +1,98 @@
+package com.knu.algo_hive.chat.handler;
+
+import com.knu.algo_hive.chat.entity.ChatMessage;
+import com.knu.algo_hive.chat.repository.ChatMessageRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class ChatWebSocketHandler extends TextWebSocketHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(ChatWebSocketHandler.class);
+
+    private final Map<String, WebSocketSession> sessionMap = new ConcurrentHashMap<>();
+    private final ChatMessageRepository chatMessageRepository;
+
+    public ChatWebSocketHandler(ChatMessageRepository chatMessageRepository) {
+        this.chatMessageRepository = chatMessageRepository;
+    }
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        String sessionId = session.getId();
+        logger.info("New connection established: sessionId = {}", sessionId);
+    }
+
+    @Override
+    public void handleTextMessage(WebSocketSession session, TextMessage message) {
+        String userMessage = message.getPayload();
+
+        if (session.getAttributes().get("username") == null) {
+            String username = userMessage;
+
+            if (sessionMap.containsKey(username)) {
+                try {
+                    session.sendMessage(new TextMessage("username 중복"));
+                    session.close();
+                } catch (Exception e) {
+                    logger.error("Error closing session for duplicate username: {}", username, e);
+                }
+                return;
+            }
+
+            session.getAttributes().put("username", username);
+            sessionMap.put(username, session);
+
+            broadcastMessage("💬 " + username + "님이 채팅방에 입장하셨습니다!");
+            logger.info("Username {} associated with sessionId {}", username, session.getId());
+            return;
+        }
+
+        String username = (String) session.getAttributes().get("username");
+
+        if (username == null) {
+            logger.warn("Error: Username not found in session.");
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        String formattedTime = now.format(DateTimeFormatter.ofPattern("HH:mm"));
+
+        ChatMessage chatMessage = new ChatMessage(username, userMessage);
+        chatMessageRepository.save(chatMessage);
+
+        broadcastMessage("[" + formattedTime + "] " + username + ": " + userMessage);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        String username = (String) session.getAttributes().get("username");
+
+        if (username != null) {
+            sessionMap.remove(username);
+
+            broadcastMessage("💬 " + username + "님이 채팅방을 떠났습니다.");
+            logger.info("User {} disconnected.", username);
+        }
+    }
+
+    private void broadcastMessage(String message) {
+        for (WebSocketSession session : sessionMap.values()) {
+            try {
+                session.sendMessage(new TextMessage(message));
+            } catch (Exception e) {
+                logger.error("Error broadcasting message: {}", message, e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/knu/algo_hive/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/knu/algo_hive/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,7 @@
+package com.knu.algo_hive.chat.repository;
+
+import com.knu.algo_hive.chat.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/src/main/java/com/knu/algo_hive/common/config/WebConfig.java
+++ b/src/main/java/com/knu/algo_hive/common/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.knu.algo_hive.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/com/knu/algo_hive/common/config/WebSocketConfig.java
+++ b/src/main/java/com/knu/algo_hive/common/config/WebSocketConfig.java
@@ -1,0 +1,42 @@
+package com.knu.algo_hive.common.config;
+
+import com.knu.algo_hive.chat.handler.ChatWebSocketHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServerEndpointExporter;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
+import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
+
+@Configuration
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final ChatWebSocketHandler chatWebSocketHandler;
+
+    public WebSocketConfig(ChatWebSocketHandler chatWebSocketHandler) {
+        this.chatWebSocketHandler = chatWebSocketHandler;
+    }
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(chatWebSocketHandler, "/api/chat")
+                .addInterceptors(new HttpSessionHandshakeInterceptor())
+                .setAllowedOrigins("*");
+    }
+
+    @Bean
+    public ServletServerContainerFactoryBean servletServerContainer() {
+        ServletServerContainerFactoryBean factoryBean = new ServletServerContainerFactoryBean();
+        factoryBean.setMaxTextMessageBufferSize(1000000);
+        factoryBean.setMaxBinaryMessageBufferSize(1000000);
+        return factoryBean;
+    }
+
+    @Bean
+    public ServerEndpointExporter serverEndpointExporter() {
+        return new ServerEndpointExporter();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #16 

## 📝 작업 내용

- 웹소켓 config 설정
- cors open
- 웹소켓 handler 구현
- 프론트 임시 구현으로 테스트
- 채팅 저장기능 구현

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/ee25c22e-f098-45a8-9224-51cd7b0ae4da)
![image](https://github.com/user-attachments/assets/06f42550-9580-46b5-a5ad-c0b487c70551)

## 💬 리뷰 요구사항(선택)

웹소켓을 처음 써봐서 헷갈리네요
일단 로컬에서는 정상 작동하는 것 같습니다
서버 내부에서 웹서버 설정이 필요해서 서버 배포 후 추가 작업 예정입니다

일반적인 rest api를 통한 통신이 아닌, 서버에서 웹소켓을 열어두고 프론트에서 해당 웹소켓에 접속하여
세션을 이용한 실시간 양방향 통신을 진행하는 방식으로 구현하였습니다.

따로 user 정보를 받지 않고 유저가 직접 이름을 입력하여 닉네임으로 채팅할 수 있도록 구현하였습니다. (중복검사 가능)

db에는 유저 이름과 채팅 내용, 채팅 시간을 저장합니다. 아직은 이르지만 이후 활용가능성이 있지 않을까 싶네요!

## ⏰ 현재 버그
로컬에서는 문제 없습니다.

## ✏ Git Close

close #16 
