### PR TITLE
Feat : 인증/인가 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,10 +33,13 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework:spring-messaging'
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/knu/algo_hive/auth/config/SecurityConfig.java
+++ b/src/main/java/com/knu/algo_hive/auth/config/SecurityConfig.java
@@ -1,0 +1,62 @@
+package com.knu.algo_hive.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception{
+        httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests((authorize) -> authorize
+                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .anyRequest().authenticated())
+                .sessionManagement((session) -> session
+                        .maximumSessions(1)
+                        .maxSessionsPreventsLogin(true));
+        return httpSecurity.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            UserDetailsService userDetailsService,
+            PasswordEncoder passwordEncoder) {
+        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
+        authenticationProvider.setUserDetailsService(userDetailsService);
+        authenticationProvider.setPasswordEncoder(passwordEncoder);
+        return new ProviderManager(authenticationProvider);
+    }
+
+    @Bean
+    public SecurityContextHolderStrategy securityContextHolderStrategy() {
+        return SecurityContextHolder.getContextHolderStrategy();
+    }
+
+    @Bean
+    public HttpSessionSecurityContextRepository securityContextRepository() {
+        HttpSessionSecurityContextRepository repository = new HttpSessionSecurityContextRepository();
+        repository.setSpringSecurityContextKey(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY);
+        return repository;
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/knu/algo_hive/auth/controller/AuthRestController.java
+++ b/src/main/java/com/knu/algo_hive/auth/controller/AuthRestController.java
@@ -1,69 +1,83 @@
 package com.knu.algo_hive.auth.controller;
 
 import com.knu.algo_hive.auth.dto.*;
+import com.knu.algo_hive.auth.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import jakarta.mail.MessagingException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
+@AllArgsConstructor
 @RestController
 @RequestMapping("api/v1/auth")
 @Tag(name = "인증/인가 기능", description = "회원 인증 및 인가 기능을 위한 api")
 public class AuthRestController {
+    private final MemberService memberService;
+
     @Operation(summary = "회원 가입 기능(미구현)",
             description = "닉네임, 이메일, 비밀번호를 입력받아 회원가입을 진행한다.",
             security = @SecurityRequirement(name = "Session 제외"))
     @PostMapping("/register")
-    public String register(@RequestBody RegisterRequest registerRequest){
+    public ResponseEntity<?> register(@RequestBody RegisterRequest registerRequest){
+        memberService.register(registerRequest);
 
-        return "성공";
+        return ResponseEntity.ok("회원가입에 성공하였습니다.");
     }
 
-    @Operation(summary = "로그인 기능(미구현)",
+    @Operation(summary = "로그인 기능",
             description = "이메일, 비밀번호를 입력받아 로그인을 진행한다.",
             security = @SecurityRequirement(name = "Session 제외"))
     @PostMapping("/login")
-    public String login(@RequestBody LoginRequest loginRequest){
+    public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest, HttpServletRequest request, HttpServletResponse response){
+        memberService.login(loginRequest, request, response);
 
-        return "성공";
+        return ResponseEntity.ok("로그인에 성공하였습니다.");
     }
 
-    @Operation(summary = "이메일 인증 기능 - 인증번호 발급(미구현)",
+    @Operation(summary = "이메일 인증 기능 - 인증번호 발급",
             description = "이메일을 입력받아 인증번호를 생성한다.",
             security = @SecurityRequirement(name = "Session 제외"))
     @PostMapping("/code")
-    public String sendVerificationCode(@RequestBody EmailRequest emailRequest){
+    public ResponseEntity<?> sendVerificationCode(@RequestBody EmailRequest emailRequest) throws MessagingException {
+        memberService.postCode(emailRequest.email());
 
-        return "성공";
+        return ResponseEntity.ok("인증번호가 발급되었습니다.");
     }
 
-    @Operation(summary = "이메일 인증 기능 - 인증번호 확인(미구현)",
+    @Operation(summary = "이메일 인증 기능 - 인증번호 확인",
             description = "이메일과 인증번호를 입력받아 인증번호를 확인한다.",
             security = @SecurityRequirement(name = "Session 제외"))
     @PostMapping("/verify")
-    public String verifyEmail(@RequestBody VerificationRequest verificationRequest){
+    public ResponseEntity<?> verifyEmail(@RequestBody VerificationRequest verificationRequest){
+        memberService.verifyCode(verificationRequest.email(), verificationRequest.code());
 
-        return "성공";
+        return ResponseEntity.ok("이메일 인증에 성공하였습니다.");
     }
 
-    @Operation(summary = "닉네임 중복 확인(미구현)",
+    @Operation(summary = "닉네임 중복 확인",
             description = "닉네임이 다른 사용자와 중복되는지 확인한다.",
             security = @SecurityRequirement(name = "Session 제외"))
     @PostMapping("/nick-name")
-    public String checkNickName(@RequestBody NickNameRequest nickNameRequest){
+    public ResponseEntity<?> checkNickName(@RequestBody NickNameRequest nickNameRequest){
+        memberService.checkNickName(nickNameRequest.nickName());
 
-        return "성공";
+        return ResponseEntity.ok("사용 가능한 닉네임입니다.");
     }
 
-    @Operation(summary = "이메일 중복 확인(미구현)",
+    @Operation(summary = "이메일 중복 확인",
             description = "이메일이 다른 사용자와 중복되는지 확인한다.",
             security = @SecurityRequirement(name = "Session 제외"))
     @PostMapping("/email")
-    public String checkEmail(@RequestBody EmailRequest emailRequest){
+    public ResponseEntity<?> checkEmail(@RequestBody EmailRequest emailRequest){
+        memberService.checkEmail(emailRequest.email());
 
-        return "성공";
+        return ResponseEntity.ok("사용 가능한 이메일입니다.");
     }
 }

--- a/src/main/java/com/knu/algo_hive/auth/entity/Member.java
+++ b/src/main/java/com/knu/algo_hive/auth/entity/Member.java
@@ -1,0 +1,33 @@
+package com.knu.algo_hive.auth.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Entity
+@Getter
+
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @NotNull
+    @Column(unique = true)
+    private String nickName;
+
+    @NotNull
+    @Column(unique = true)
+    private String email;
+
+    @NotNull
+    private String password;
+
+    public Member(){}
+
+    public Member(String nickName, String email, String password){
+        this.nickName = nickName;
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/knu/algo_hive/auth/repository/MemberRepository.java
+++ b/src/main/java/com/knu/algo_hive/auth/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.knu.algo_hive.auth.repository;
+
+import com.knu.algo_hive.auth.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByEmail(String email);
+    boolean existsByNickName(String nickName);
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/knu/algo_hive/auth/service/CustomUserDetails.java
+++ b/src/main/java/com/knu/algo_hive/auth/service/CustomUserDetails.java
@@ -1,0 +1,53 @@
+package com.knu.algo_hive.auth.service;
+
+import com.knu.algo_hive.auth.entity.Member;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private Member member;
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    // Role 관련 부분, 현재는 지정하지 않아서 따로 없음
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+}

--- a/src/main/java/com/knu/algo_hive/auth/service/MailService.java
+++ b/src/main/java/com/knu/algo_hive/auth/service/MailService.java
@@ -1,0 +1,60 @@
+package com.knu.algo_hive.auth.service;
+
+import com.knu.algo_hive.common.exception.ConflictException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MailService {
+    private final JavaMailSender javaMailSender;
+    @Value("spring.mail.username")
+    private String senderEmail;
+
+    public MailService(JavaMailSender javaMailSender){
+        this.javaMailSender = javaMailSender;
+    }
+
+    public void sendMail(String email, String code) throws MessagingException {
+        MimeMessage message = this.verifyCodeTemplate(email, code);
+
+        message.setFrom(senderEmail);
+        message.setRecipients(MimeMessage.RecipientType.TO, email);
+
+        try {
+            javaMailSender.send(message); // 메일 발송
+        } catch (MailException e) {
+            e.printStackTrace();
+            throw new ConflictException("메일 발송 중 오류가 발생했습니다.");
+        }
+    }
+
+    public MimeMessage verifyCodeTemplate(String email, String code) throws MessagingException {
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        StringBuilder sb = new StringBuilder();
+
+        sb.append( "<h2>안녕하세요.</h2>");
+        sb.append( "<h2>Algo-Hive 입니다.</h2>");
+        sb.append( "<br>");
+        sb.append( "<p>아래 인증코드를 회원가입 페이지에 입력해주세요</p>");
+        sb.append( "<br>");
+        sb.append( "<br>");
+        sb.append( "<div align='center' style='border:1px solid black'>");
+        sb.append( "<h3 style='color:blue'>회원가입 인증코드 입니다</h3>");
+        sb.append( "<div style='font-size:130%'>");
+        sb.append("<strong>").append(code).append("</strong></div><br/>");
+        sb.append( "</div>");
+
+        String body = sb.toString();
+
+        message.setSubject("[Algo Hive] 이메일 인증번호");
+        message.setText(body, "UTF-8", "html");
+
+        return message;
+    }
+}

--- a/src/main/java/com/knu/algo_hive/auth/service/MemberService.java
+++ b/src/main/java/com/knu/algo_hive/auth/service/MemberService.java
@@ -1,0 +1,99 @@
+package com.knu.algo_hive.auth.service;
+
+import com.knu.algo_hive.auth.dto.LoginRequest;
+import com.knu.algo_hive.auth.dto.RegisterRequest;
+import com.knu.algo_hive.auth.entity.Member;
+import com.knu.algo_hive.auth.repository.MemberRepository;
+import com.knu.algo_hive.common.exception.BadRequestException;
+import jakarta.mail.MessagingException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+public class MemberService{
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final SecurityContextHolderStrategy securityContextHolderStrategy;
+    private final HttpSessionSecurityContextRepository securityContextRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final MailService mailService;
+
+    private final long ACCESS_THREE_MINUTES = 1000 * 60 * 3;
+    private final long ACCESS_TEN_MINUTES = 1000 * 60 * 10;
+
+    public void register(RegisterRequest registerRequest){
+        checkEmail(registerRequest.email());
+        checkNickName(registerRequest.nickName());
+
+        if(!Boolean.parseBoolean((String)redisTemplate.opsForHash().get(registerRequest.email(), "verified")))
+            throw new BadRequestException("이메일 인증을 하지 않았습니다.");
+
+        Member member = new Member(registerRequest.nickName(),
+                registerRequest.email(),
+                passwordEncoder.encode(registerRequest.password()));
+
+        memberRepository.save(member);
+    }
+
+    public void login(LoginRequest loginRequest, HttpServletRequest request, HttpServletResponse response){
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(loginRequest.email(), loginRequest.password());
+
+        Authentication authentication = authenticationManager.authenticate(authenticationToken);
+
+        SecurityContext context = this.securityContextHolderStrategy.createEmptyContext();
+        context.setAuthentication(authentication);
+        securityContextRepository.saveContext(context, request, response);
+    }
+
+    public void checkEmail(String email){
+        if(memberRepository.existsByEmail(email)) throw new BadRequestException("중복된 이메일이 있습니다.");
+    }
+
+    public void checkNickName(String nickname){
+        if(memberRepository.existsByNickName(nickname)) throw new BadRequestException("중복된 닉네임이 있습니다.");
+    }
+
+    public void postCode(String email) throws MessagingException {
+        checkEmail(email);
+        Random random = new Random();
+        String code = String.format("%04d", random.nextInt(10000));
+
+        mailService.sendMail(email, code);
+
+        redisTemplate.opsForHash().put(email, "code", code);
+        redisTemplate.opsForHash().put(email, "verified", false);
+
+        redisTemplate.expire(email, ACCESS_THREE_MINUTES, TimeUnit.MILLISECONDS);
+    }
+
+    public void verifyCode(String email, String code){
+        checkEmail(email);
+        String storedCode = (String) redisTemplate.opsForHash().get(email, "code");
+
+        if(storedCode.equals(code)){
+            redisTemplate.opsForHash().put(email, "verified", true);
+            redisTemplate.expire(email, ACCESS_TEN_MINUTES, TimeUnit.MILLISECONDS);
+            return;
+        }
+
+        throw new BadRequestException("인증번호를 잘못 입력하였습니다.");
+    }
+}

--- a/src/main/java/com/knu/algo_hive/auth/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/knu/algo_hive/auth/service/UserDetailsServiceImpl.java
@@ -1,0 +1,26 @@
+package com.knu.algo_hive.auth.service;
+
+import com.knu.algo_hive.auth.CustomUserDetails;
+import com.knu.algo_hive.auth.entity.Member;
+import com.knu.algo_hive.auth.repository.MemberRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    public UserDetailsServiceImpl(MemberRepository memberRepository){
+        this.memberRepository = memberRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Optional<Member> memberOptional = memberRepository.findByEmail(email);
+        return memberOptional.map(CustomUserDetails::new).orElse(null);
+    }
+}

--- a/src/main/java/com/knu/algo_hive/auth/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/knu/algo_hive/auth/service/UserDetailsServiceImpl.java
@@ -1,6 +1,5 @@
 package com.knu.algo_hive.auth.service;
 
-import com.knu.algo_hive.auth.CustomUserDetails;
 import com.knu.algo_hive.auth.entity.Member;
 import com.knu.algo_hive.auth.repository.MemberRepository;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/src/main/java/com/knu/algo_hive/common/config/MailConfig.java
+++ b/src/main/java/com/knu/algo_hive/common/config/MailConfig.java
@@ -1,0 +1,45 @@
+package com.knu.algo_hive.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.debug", "true");
+        props.put("mail.smtp.localhost", "algohive");
+
+        mailSender.setJavaMailProperties(props);
+        return mailSender;
+    }
+}

--- a/src/main/java/com/knu/algo_hive/common/config/RedisConfig.java
+++ b/src/main/java/com/knu/algo_hive/common/config/RedisConfig.java
@@ -1,0 +1,31 @@
+package com.knu.algo_hive.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        Jackson2JsonRedisSerializer<Object> serializer = new Jackson2JsonRedisSerializer<>(Object.class);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        // Hash key serializer
+        template.setHashKeySerializer(new StringRedisSerializer());
+        // Hash value serializer
+        template.setHashValueSerializer(new GenericToStringSerializer<>(Object.class));
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,12 @@ spring.h2.console.enabled=false
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.rabbitmq.publisher-returns=true
+
+server.servlet.session.timeout=30m
+
+spring.mail.username=${SMTP_EMAIL}
+spring.mail.password=${SMTP_PASSWORD}
+
+spring.data.redis.host=${DB_HOST}
+spring.data.redis.port=6379
+spring.data.redis.password=${REDIS_PASSWORD}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #9 

## 📝 작업 내용

>
1. 회원가입 기능
1-1. 닉네임 중복 확인 기능
- Member 엔티티에서 현재 사용하는 닉네임이 있는지 확인하는 existsByNickName() 메소드를 활용하여 구현하였습니다.

1-2. 이메일 중복 확인 기능
- Member 엔티티에서 현재 사용하는 이메일이 있는지 확인하는 existsByEmail() 메소드를 활용하여 구현하였습니다.

1-3. 인증번호 발급 기능
- 먼저 이메일 중복 여부를 확인하고, 인증번호로 0~9999 사이의 임의의 네자리 숫자를 Redis에 email(Key)-code(Value) 형태로 저장합니다. 또한 인증 여부를 확인하는 verified 변수가 false로 저장됩니다. 해당 인증번호는 3분 동안 유효합니다. 3분이 지나면 인증번호가 만료되어 Redis에서 삭제됩니다.

1-4. 인증번호 확인 기능
- 먼저 이메일 중복 여부를 확인하고, Redis에 있는 인증번호와 입력한 인증번호가 일치하는지 확인합니다. 일치할 경우 인증 여부를 확인하는 verified 변수가 true로 설정되고, 유효시간은 10분으로 재조정됩니다. (이메일 인증 후 만료되어 삭제되는 것을 방지하기 위함입니다.)

1-5. 비밀번호 암호화 기능
- 비밀번호는 평문 그대로 저장할 경우 해킹 시 개인정보가 유출되는 문제점이 있습니다. 이를 해결하기 위해 Spring Security의 기능 중 하나인 암호화를 사용하였습니다. 그 중에서 복호화할 수 없는 BCryptPasswordEncoder를 통해 비밀번호를 암호화하여 데이터베이스에 저장합니다. 추후에 로그인 시에는 평문 비밀번호를 암호화하여 암호화된 문자열과 데이터베이스에 있는 문자열을 비교하여 비밀번호가 일치하는지 확인합니다. 

3. 로그인 기능
- 사용자는 회원가입을 한 후 이메일과 비밀번호를 입력하여 로그인을 진행합니다. 

4. 그 외 부가적인 내용
- 세션 클러스터링 : 현재 서버를 두 대 이상 사용하고 있기 때문에 세션 상태를 별도의 서버에서 관리해야 서버를 교체하더라도 서버 간 동기화가 제대로 이루어질 수 있습니다. 이를 해결하기 위해 HttpSessionSecurityContextRepository의 데이터를 Redis에 기록함으로써 해결하였습니다. (추가적인 설정이 필요하나 찾아봤는데 redis 의존성을 추가하기만 하면 자동으로 Redis에 기록된다고 하더라구요... 신기하긴한데 직접 확인을 못해서 배포하면서 확인해봐야할 것 같습니다.)
- 이메일 인증 : STMP를 통해 이메일을 전송하며, 이메일의 형식은 Html 및 CSS를 통해 변경할 수 있습니다. 피그마에 정해진 형식이 따로 없어서 임의로 제작하였습니다. 이 부분은 수정할 수 있습니다. (발신자 이메일 주소는 현재는 제 이메일 주소로 하였는데, 이 부분도 새로운 구글 계정을 생성한 후 앱 비밀번호를 발급받아 properties 파일을 변경하여 수정할 수 잇습니다.)
![image](https://github.com/user-attachments/assets/a12111bc-8a08-4438-8acd-809d0d43977c)
- CustomUserDetails.java : Spring Security에 사용되는 사용자의 정보를 담는 인터페이스인 UserDetails를 구현한 클래스입니다. 우리 프로젝트의 경우 Member 엔티티에서 정보를 담아와야하기 때문에 username으로 email을, password 또한 member 엔티티의 password를 지정하였습니다. 현재는 권한에 따른 별도의 페이지가 없어 권한을 나타내는 authority는 따로 지정하지 않았습니다.
- UserDetailsServiceImpl.java : username을 통해 엔티티에서 UserDetail을 가져오는 인터페이스 UserDetailsService를 구현한 클래스입니다. Member 레포지토리에서 이메일을 통해 엔티티를 가져와 CustomUserDetails를 생성하여 리턴합니다.
- MemberService 클래스의 login() : 여기서 사용자가 입력한 이메일 및 비밀번호가 Member 엔티티와 일치하는지 확인하고, 인증된 사용자인 경우 securityContextRepository에 저장합니다. 

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/723f51cb-ec63-4757-8edc-636f74fc1d42)

회원가입의 시퀀스 다이어그램입니다.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 아무래도 Spring Security를 처음 사용하다보니 작성하면서도 정확할 지 걱정이 많이됩니다 ㅠㅠ 문제되는 부분 말해주시면 빠르게 고치겠습니다!

## ⏰ 현재 버그
> 로컬 환경에서 테스트해보았을 때에는 정상적으로 작동되었는데, 서버 배포된 후에도 지속적으로 지켜봐야할 것 같습니다.

## ✏ Git Close
> close #9

