### PR TITLE
Feat: 채팅방 접속자 목록 조회기능 구현

### DIFF
--- a/src/main/java/com/knu/algo_hive/chat/controller/WebSocketChatController.java
+++ b/src/main/java/com/knu/algo_hive/chat/controller/WebSocketChatController.java
@@ -5,19 +5,14 @@ import com.knu.algo_hive.chat.dto.ChatMessageRequest;
 import com.knu.algo_hive.chat.dto.UserInRoomResponse;
 import com.knu.algo_hive.chat.dto.UserNameRequest;
 import com.knu.algo_hive.chat.rabbitmq.MessageProducer;
-import com.knu.algo_hive.chat.rabbitmq.UserStatusConsumer;
 import com.knu.algo_hive.chat.rabbitmq.UserStatusProducer;
 import com.knu.algo_hive.chat.service.ChatMessageService;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Controller;
-
-import java.util.List;
-import java.util.Set;
 
 @Controller
 public class WebSocketChatController {

--- a/src/main/java/com/knu/algo_hive/chat/controller/WebSocketChatController.java
+++ b/src/main/java/com/knu/algo_hive/chat/controller/WebSocketChatController.java
@@ -2,24 +2,34 @@ package com.knu.algo_hive.chat.controller;
 
 import com.knu.algo_hive.chat.dto.ChatMessageInfo;
 import com.knu.algo_hive.chat.dto.ChatMessageRequest;
+import com.knu.algo_hive.chat.dto.UserInRoomResponse;
 import com.knu.algo_hive.chat.dto.UserNameRequest;
 import com.knu.algo_hive.chat.rabbitmq.MessageProducer;
+import com.knu.algo_hive.chat.rabbitmq.UserStatusConsumer;
+import com.knu.algo_hive.chat.rabbitmq.UserStatusProducer;
 import com.knu.algo_hive.chat.service.ChatMessageService;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Controller;
+
+import java.util.List;
+import java.util.Set;
 
 @Controller
 public class WebSocketChatController {
 
     private final MessageProducer messageProducer;
     private final ChatMessageService chatMessageService;
+    private final UserStatusProducer userStatusProducer;
 
-    public WebSocketChatController(MessageProducer messageProducer, ChatMessageService chatMessageService) {
+    public WebSocketChatController(MessageProducer messageProducer, ChatMessageService chatMessageService, UserStatusProducer userStatusProducer) {
         this.messageProducer = messageProducer;
         this.chatMessageService = chatMessageService;
+        this.userStatusProducer = userStatusProducer;
     }
 
     @MessageMapping("/chat/{roomName}")
@@ -42,5 +52,10 @@ public class WebSocketChatController {
         ChatMessageInfo chatMessageInfo = new ChatMessageInfo(sender, userNameRequest.userName(), roomName);
 
         messageProducer.sendMessage(chatMessageInfo);
+    }
+
+    @MessageMapping("/chat/join")
+    public void joinChat(@Payload UserInRoomResponse userInRoomResponse, StompHeaderAccessor headerAccessor) {
+        userStatusProducer.sendUserJoinMessage(userInRoomResponse.userName(), userInRoomResponse.roomName(), headerAccessor);
     }
 }

--- a/src/main/java/com/knu/algo_hive/chat/dto/UserInRoomResponse.java
+++ b/src/main/java/com/knu/algo_hive/chat/dto/UserInRoomResponse.java
@@ -1,0 +1,8 @@
+package com.knu.algo_hive.chat.dto;
+
+public record UserInRoomResponse(
+        String userName,
+        String roomName,
+        boolean isJoin
+) {
+}

--- a/src/main/java/com/knu/algo_hive/chat/dto/UsersResponse.java
+++ b/src/main/java/com/knu/algo_hive/chat/dto/UsersResponse.java
@@ -1,0 +1,7 @@
+package com.knu.algo_hive.chat.dto;
+
+public record UsersResponse(
+        String userName,
+        String roomName
+) {
+}

--- a/src/main/java/com/knu/algo_hive/chat/rabbitmq/UserStatusConsumer.java
+++ b/src/main/java/com/knu/algo_hive/chat/rabbitmq/UserStatusConsumer.java
@@ -1,0 +1,39 @@
+package com.knu.algo_hive.chat.rabbitmq;
+
+import com.knu.algo_hive.chat.dto.UserInRoomResponse;
+import com.knu.algo_hive.chat.dto.UsersResponse;
+import lombok.Getter;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+public class UserStatusConsumer {
+
+    private static final String USER_QUEUE_NAME = "userQueue";
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Getter
+    private final Set<UsersResponse> connectedUsers = new HashSet<>();
+
+    public UserStatusConsumer(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    @RabbitListener(queues = USER_QUEUE_NAME, concurrency = "5-10")
+    public void receiveUserStatus(UserInRoomResponse userInRoomResponse) {
+
+        if (userInRoomResponse.isJoin()) {
+            connectedUsers.add(new UsersResponse(userInRoomResponse.userName(), userInRoomResponse.roomName()));
+        } else {
+            connectedUsers.removeIf(user -> user.userName().equals(userInRoomResponse.userName()));
+        }
+
+        messagingTemplate.convertAndSend("/topic/users", connectedUsers);
+        System.out.println(connectedUsers);
+    }
+}

--- a/src/main/java/com/knu/algo_hive/chat/rabbitmq/UserStatusProducer.java
+++ b/src/main/java/com/knu/algo_hive/chat/rabbitmq/UserStatusProducer.java
@@ -1,0 +1,43 @@
+package com.knu.algo_hive.chat.rabbitmq;
+
+import com.knu.algo_hive.chat.dto.UserInRoomResponse;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Service
+public class UserStatusProducer {
+
+    private static final String USER_QUEUE_NAME = "userQueue";
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public UserStatusProducer(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    @Async
+    public void sendUserJoinMessage(String userName, String roomName, StompHeaderAccessor headerAccessor) {
+        UserInRoomResponse userInRoomResponse = new UserInRoomResponse(userName, roomName, true);
+
+        headerAccessor.getSessionAttributes().put("username", userName);
+        headerAccessor.getSessionAttributes().put("roomName", roomName);
+
+        rabbitTemplate.convertAndSend(USER_QUEUE_NAME, userInRoomResponse);
+    }
+
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+        String username = (String) headerAccessor.getSessionAttributes().get("username");
+        String roomName = (String) headerAccessor.getSessionAttributes().get("roomName");
+
+        if (username != null && roomName != null) {
+            UserInRoomResponse userInRoomResponse = new UserInRoomResponse(username, roomName, false);
+            rabbitTemplate.convertAndSend(USER_QUEUE_NAME, userInRoomResponse);
+        }
+    }
+}

--- a/src/main/java/com/knu/algo_hive/common/config/RabbitConfig.java
+++ b/src/main/java/com/knu/algo_hive/common/config/RabbitConfig.java
@@ -13,7 +13,9 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RabbitConfig {
 
-    private static final String QUEUE_NAME = "algoQueue";
+    private static final String MESSAGE_QUEUE_NAME = "algoQueue";
+    private static final String USER_QUEUE_NAME = "userQueue";
+
     private static final boolean DURABLE = true;
     private static final int CONNECTION_TIMEOUT = 10000;
     private static final int REQUESTED_HEARTBEAT = 60;
@@ -31,8 +33,13 @@ public class RabbitConfig {
     private int port;
 
     @Bean
-    public Queue algoQueue() {
-        return new Queue(QUEUE_NAME, DURABLE);
+    public Queue messageQueue() {
+        return new Queue(MESSAGE_QUEUE_NAME, DURABLE);
+    }
+
+    @Bean
+    public Queue userQueue() {
+        return new Queue(USER_QUEUE_NAME, DURABLE);
     }
 
     @Bean


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #34 

## 📝 작업 내용

- 유저 조회용 userQueue 생성
- rabbitMQ와 연동
- 웹소켓 종료 리스너 구현
- dto를 통해 구분
- 프론트코드 수정
- 테스트

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/2c85bbe4-eb25-45f4-8b1a-d2ff5b18b7bb)
![image](https://github.com/user-attachments/assets/35d0164c-6ec1-4630-8908-1867b634d3cd)
![image](https://github.com/user-attachments/assets/c416fa51-1835-4e8c-add6-e7798ea10be6)
![image](https://github.com/user-attachments/assets/9cc94cc9-2658-4b37-adf3-b173fe8c46cd)
![image](https://github.com/user-attachments/assets/f128ea1f-4a73-4bf0-8c92-e386d3bf88d5)

## 💬 리뷰 요구사항(선택)

### 요약
WebSocket을 이용해 사용자 연결 및 채팅방 입장, 실시간 메시지 수신, 사용자 목록 업데이트 등을 처리하는 로직을 구현했습니다. 
사용자는 채팅방에 입장하기 전에 이름을 설정하고, 이를 WebSocket 서버에 전송해 사용자 정보를 등록합니다. 

이후 사용자는 채팅방의 메시지를 실시간으로 수신하고, 전역 사용자 목록을 실시간으로 갱신하여 화면에 반영할 수 있습니다. 
채팅방에 입장할 때마다 입장 트리거가 작동해 여러 pod에서 구동 가능하도록 구현하였고, 채팅방에서 발생하는 메시지와 사용자 목록은 실시간으로 업데이트됩니다. 사용자가 채팅방을 떠날 때는 퇴장 트리거를 통해 접속 유저를 확인 가능하고, UI는 이를 자동으로 갱신하도록 임시로 구현하였습니다. 

또한, 여러 개의 Pod에서 동시에 WebSocket 서버가 동작할 수 있도록 로드 밸런싱을 고려하여 설계되어, 3개 이상의 Pod에서도 안정적으로 작동할 수 있습니다.

### 접속자 조회 흐름

1. 사용자 이름 설정 및 WebSocket 연결
사용자가 채팅방에 입장하기 전에, 반드시 사용자 이름을 설정해야 합니다. 사용자가 이름을 설정하면 해당 이름을 WebSocket 서버에 전송하여 사용자를 등록합니다. 이 과정은 채팅방에 처음 연결할 때 발생하며, 이름 설정 후 WebSocket 서버와 연결을 통해 해당 사용자를 채팅방에 추가할 수 있습니다.

2. 채팅방에 연결
사용자가 이름을 설정하고 나면, WebSocket을 통해 채팅방에 연결됩니다. 이때 채팅방의 이름이 제공되며, 사용자는 해당 채팅방에 입장하게 됩니다. 만약 사용자가 채팅방을 변경할 경우, 새로운 채팅방으로 WebSocket 연결을 다시 설정하여 입장합니다.

3. WebSocket 연결 및 메시지 구독
WebSocket 연결이 성공하면 사용자는 해당 채팅방에서 발생하는 메시지를 실시간으로 받을 수 있도록 설정됩니다. 또한, 사용자는 전역 사용자 목록을 구독하여 실시간으로 채팅방에 속한 다른 사용자의 목록을 업데이트할 수 있습니다. 메시지가 채팅방에 도달하면, 이를 실시간으로 처리하여 화면에 표시합니다.

4. 사용자 입장 알림
사용자가 채팅방에 입장할 때마다 rabbitMQ를 통해 서버로 queue를 전달하고 소비하여 전체 접속자 현황을 여러 pod에서 확인할 수 있습니다.

5. 주요 흐름
WebSocket 연결: 클라이언트는 WebSocket 서버와 연결하여 채팅방에서 발생하는 메시지를 실시간으로 수신합니다.
사용자 이름 설정: 사용자는 채팅방에 입장하기 전에 이름을 설정하고, 이를 서버에 전송하여 사용자를 등록합니다.
메시지 및 사용자 목록 구독: 채팅방의 메시지와 전역 사용자 목록을 구독하여 실시간으로 갱신된 정보를 화면에 반영합니다.
사용자 입장 알림: 사용자가 채팅방에 입장하면 이를 서버를 통해 저장합니다.

## ⏰ 현재 버그
로컬에서는 없습니다.

## ✏ Git Close

close #34 