### PR TITLE
Feat: 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/knu/algo_hive/post/controller/LikeController.java
+++ b/src/main/java/com/knu/algo_hive/post/controller/LikeController.java
@@ -1,10 +1,13 @@
 package com.knu.algo_hive.post.controller;
 
+import com.knu.algo_hive.auth.service.CustomUserDetails;
 import com.knu.algo_hive.post.dto.LikeCountResponse;
 import com.knu.algo_hive.post.dto.LikeStatusResponse;
+import com.knu.algo_hive.post.service.LikeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -14,28 +17,35 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "게시물_좋아요", description = "게시물의 좋아요 관련 API")
 public class LikeController {
 
+    private final LikeService likeService;
+
+    public LikeController(LikeService likeService) {
+        this.likeService = likeService;
+    }
+
     @GetMapping("/api/v1/posts/{postId}/likes/count")
-    @Operation(summary = "좋아요 개수 조회(미구현)",
+    @Operation(summary = "좋아요 개수 조회",
             description = "좋아요 개수 조회"
     )
-    public ResponseEntity<LikeCountResponse> getLikeCount(@PathVariable String postId) {
-        LikeCountResponse likeCountResponse = new LikeCountResponse(34);
-        return ResponseEntity.ok(likeCountResponse);
+    public ResponseEntity<LikeCountResponse> getLikeCount(@PathVariable Long postId) {
+        return ResponseEntity.ok(likeService.getLikeCount(postId));
     }
 
     @PutMapping("/api/v1/posts/{postId}/likes/status")
-    @Operation(summary = "좋아요 상태 변경(좋아요/좋아요 취소) (미구현)",
+    @Operation(summary = "좋아요 상태 변경(좋아요/좋아요 취소)",
             description = "좋아요 상태 변경. api 요청마다 상태가 반전됨. 200 응답시 현 좋아요 상태 반환"
     )
-    public ResponseEntity<LikeStatusResponse> changeLikeStatus(@PathVariable String postId) {
-        return ResponseEntity.ok(new LikeStatusResponse(true));
+    public ResponseEntity<LikeStatusResponse> changeLikeStatus(@PathVariable Long postId,
+                                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(likeService.changeLikeStatus(postId, userDetails.getUsername()));
     }
 
     @GetMapping("/api/v1/posts/{postId}/likes/status")
-    @Operation(summary = " 좋아요 상태 조회 (미구현)",
+    @Operation(summary = " 좋아요 현재 상태 조회 ",
             description = "현재 유저의 해당 포스트 좋아요 상태 조회. 200 응답시 현 좋아요 상태 반환"
     )
-    public ResponseEntity<LikeStatusResponse> getLikeStatus(@PathVariable Long postId) {
-        return ResponseEntity.ok(new LikeStatusResponse(true));
+    public ResponseEntity<LikeStatusResponse> getLikeStatus(@PathVariable Long postId,
+                                                            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(likeService.getLikeStatus(postId, userDetails.getUsername()));
     }
 }

--- a/src/main/java/com/knu/algo_hive/post/controller/LikeController.java
+++ b/src/main/java/com/knu/algo_hive/post/controller/LikeController.java
@@ -37,7 +37,7 @@ public class LikeController {
     )
     public ResponseEntity<LikeStatusResponse> changeLikeStatus(@PathVariable Long postId,
                                                                @AuthenticationPrincipal CustomUserDetails userDetails) {
-        return ResponseEntity.ok(likeService.changeLikeStatus(postId, userDetails.getUsername()));
+        return ResponseEntity.ok(likeService.changeLikeStatusWithRetry(postId, userDetails.getUsername()));
     }
 
     @GetMapping("/api/v1/posts/{postId}/likes/status")

--- a/src/main/java/com/knu/algo_hive/post/entity/Like.java
+++ b/src/main/java/com/knu/algo_hive/post/entity/Like.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
+@Table(name = "post_like")
 public class Like {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/com/knu/algo_hive/post/entity/Like.java
+++ b/src/main/java/com/knu/algo_hive/post/entity/Like.java
@@ -1,0 +1,22 @@
+package com.knu.algo_hive.post.entity;
+
+import com.knu.algo_hive.auth.entity.Member;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+public class Like {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Post post;
+
+    public Like(Member member, Post post) {
+        this.member = member;
+        this.post = post;
+    }
+}

--- a/src/main/java/com/knu/algo_hive/post/entity/Post.java
+++ b/src/main/java/com/knu/algo_hive/post/entity/Post.java
@@ -9,8 +9,6 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
 
 @Entity
 @Getter
@@ -33,6 +31,8 @@ public class Post {
     private LocalDateTime updatedAt;
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
+    @Version
+    private Integer version;
 
     public Post(String content, String summary, String thumbnail, String title, Member member) {
         this.content = content;

--- a/src/main/java/com/knu/algo_hive/post/entity/Post.java
+++ b/src/main/java/com/knu/algo_hive/post/entity/Post.java
@@ -21,6 +21,7 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
     private String title;
+    @Lob
     private String content;
     private String thumbnail;
     private String summary;

--- a/src/main/java/com/knu/algo_hive/post/repository/LikeRepository.java
+++ b/src/main/java/com/knu/algo_hive/post/repository/LikeRepository.java
@@ -12,5 +12,5 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     Optional<Like> findByPostAndMember(Post post, Member member);
 
-    Optional<Like> findByPostIdAndMemberEmail(Long postId, String email);
+    boolean existsByPostIdAndMemberEmail(Long postId, String email);
 }

--- a/src/main/java/com/knu/algo_hive/post/repository/LikeRepository.java
+++ b/src/main/java/com/knu/algo_hive/post/repository/LikeRepository.java
@@ -1,0 +1,16 @@
+package com.knu.algo_hive.post.repository;
+
+import com.knu.algo_hive.auth.entity.Member;
+import com.knu.algo_hive.post.entity.Like;
+import com.knu.algo_hive.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    int countByPostId(Long postId);
+
+    Optional<Like> findByPostAndMember(Post post, Member member);
+
+    Optional<Like> findByPostIdAndMemberEmail(Long postId, String email);
+}

--- a/src/main/java/com/knu/algo_hive/post/service/LikeService.java
+++ b/src/main/java/com/knu/algo_hive/post/service/LikeService.java
@@ -53,8 +53,7 @@ public class LikeService {
 
     @Transactional(readOnly = true)
     public LikeStatusResponse getLikeStatus(Long postId, String email) {
-        Optional<Like> likeOptional = likeRepository.findByPostIdAndMemberEmail(postId, email);
-        if (likeOptional.isPresent()) {
+        if (likeRepository.existsByPostIdAndMemberEmail(postId, email)) {
             return new LikeStatusResponse(true);
         } else {
             return new LikeStatusResponse(false);

--- a/src/main/java/com/knu/algo_hive/post/service/LikeService.java
+++ b/src/main/java/com/knu/algo_hive/post/service/LikeService.java
@@ -1,0 +1,63 @@
+package com.knu.algo_hive.post.service;
+
+import com.knu.algo_hive.auth.entity.Member;
+import com.knu.algo_hive.auth.repository.MemberRepository;
+import com.knu.algo_hive.common.exception.NotFoundException;
+import com.knu.algo_hive.post.dto.LikeCountResponse;
+import com.knu.algo_hive.post.dto.LikeStatusResponse;
+import com.knu.algo_hive.post.entity.Like;
+import com.knu.algo_hive.post.entity.Post;
+import com.knu.algo_hive.post.repository.LikeRepository;
+import com.knu.algo_hive.post.repository.PostRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    public LikeService(LikeRepository likeRepository, PostRepository postRepository, MemberRepository memberRepository) {
+        this.likeRepository = likeRepository;
+        this.postRepository = postRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public LikeCountResponse getLikeCount(Long postId) {
+        return new LikeCountResponse(likeRepository.countByPostId(postId));
+    }
+
+    @Transactional
+    public LikeStatusResponse changeLikeStatus(Long postId, String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException("member not found"));
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new NotFoundException("post not found"));
+
+        Optional<Like> likeOptional = likeRepository.findByPostAndMember(post, member);
+        if (likeOptional.isPresent()) {
+            likeOptional.ifPresent(likeRepository::delete);
+            post.setLikeCount(post.getLikeCount() - 1);
+            return new LikeStatusResponse(false);
+        } else {
+            likeRepository.save(new Like(member, post));
+            post.setLikeCount(post.getLikeCount() + 1);
+            return new LikeStatusResponse(true);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public LikeStatusResponse getLikeStatus(Long postId, String email) {
+        Optional<Like> likeOptional = likeRepository.findByPostIdAndMemberEmail(postId, email);
+        if (likeOptional.isPresent()) {
+            return new LikeStatusResponse(true);
+        } else {
+            return new LikeStatusResponse(false);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호


#39 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

- 각 게시물마다 유저의 좋아요 현황을 추적할 수 있도록하였습니다
- 유저가 게시물에서 좋아요 버튼을 누르는 상황을 상상하며 기능을 만들어보았습니다.

### Post 엔티티에 likeCount 가 int 형으로 따로 있고, Like엔티티와 연관 안 시킨 이유
 자주 사용되는 기능이 포스트 목록 페이지네이션이라고 생각했는데 그때마다 좋아요 개수를 가져오기 위해 좋아요 테이블을 일일이 조회해서 포스트의 좋아요 개수를 카운팅 할 필요도 없는거 같고, 리소스도 너무 많이쓴다고 판단하여 이렇게 코드를 작성해 보았습니다. 

좋아요 개수는 언제든지 바뀔수 있으니 사용자가 포스트를 상세조회 할 때 `/api/v1/posts/{postId}/likes/count` 이걸로 최신 좋아요 개수를 획득하는 방식으로 구성해보았습니다. 


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## ⏰ 현재 버그

## ✏ Git Close

> close #이슈번호
> 

close #39 