### PR TITLE
Refactor: 이메일 인증 메일 형식 수정, 리팩토링 및 api 문서 작업

### DIFF
--- a/src/main/java/com/knu/algo_hive/auth/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/knu/algo_hive/auth/config/CustomAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package com.knu.algo_hive.auth.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.knu.algo_hive.common.exception.ErrorCode;
 import com.knu.algo_hive.common.exception.UnauthorizedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -23,7 +24,9 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.setCharacterEncoding("UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(errorCode.getHttpStatus(), errorCode.getMessage());
         problemDetail.setTitle("Unauthorized");
 
         response.getWriter().write(objectMapper.writeValueAsString(problemDetail));

--- a/src/main/java/com/knu/algo_hive/auth/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/knu/algo_hive/auth/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.knu.algo_hive.auth.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.knu.algo_hive.common.exception.UnauthorizedException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        problemDetail.setTitle("Unauthorized");
+
+        response.getWriter().write(objectMapper.writeValueAsString(problemDetail));
+    }
+}

--- a/src/main/java/com/knu/algo_hive/auth/config/SecurityConfig.java
+++ b/src/main/java/com/knu/algo_hive/auth/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.knu.algo_hive.auth.config;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -20,17 +21,21 @@ import org.springframework.security.web.context.HttpSessionSecurityContextReposi
 @EnableWebSecurity
 public class SecurityConfig {
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity, CustomAuthenticationEntryPoint customAuthenticationEntryPoint) throws Exception {
         httpSecurity
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((authorize) -> authorize
 //                        .requestMatchers("/api/v1/auth/**").permitAll()
-//                        .anyRequest().authenticated())
-                        .anyRequest().permitAll())
+//                        .requestMatchers("/swagger-ui/**").permitAll()
+//                        .anyRequest().authenticated()
+                          .anyRequest().permitAll())
                 .sessionManagement((session) -> session
                         .maximumSessions(1)
-                        .maxSessionsPreventsLogin(true));
+                        .maxSessionsPreventsLogin(true))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                );
         return httpSecurity.build();
     }
 

--- a/src/main/java/com/knu/algo_hive/auth/controller/AuthRestController.java
+++ b/src/main/java/com/knu/algo_hive/auth/controller/AuthRestController.java
@@ -3,12 +3,17 @@ package com.knu.algo_hive.auth.controller;
 import com.knu.algo_hive.auth.dto.*;
 import com.knu.algo_hive.auth.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthRestController {
     private final MemberService memberService;
 
-    @Operation(summary = "회원 가입 기능(미구현)",
+    @Operation(summary = "회원 가입 기능",
             description = "닉네임, 이메일, 비밀번호를 입력받아 회원가입을 진행한다.",
             security = @SecurityRequirement(name = "Session 제외"))
     @PostMapping("/register")

--- a/src/main/java/com/knu/algo_hive/auth/controller/AuthRestController.java
+++ b/src/main/java/com/knu/algo_hive/auth/controller/AuthRestController.java
@@ -2,18 +2,16 @@ package com.knu.algo_hive.auth.controller;
 
 import com.knu.algo_hive.auth.dto.*;
 import com.knu.algo_hive.auth.service.MemberService;
+import com.knu.algo_hive.common.annotation.ApiErrorCodeExamples;
+import com.knu.algo_hive.common.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
-import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,60 +28,65 @@ public class AuthRestController {
     @Operation(summary = "회원 가입 기능",
             description = "닉네임, 이메일, 비밀번호를 입력받아 회원가입을 진행한다.",
             security = @SecurityRequirement(name = "Session 제외"))
+    @ApiErrorCodeExamples({ErrorCode.OK, ErrorCode.DUPLICATE_EMAIL, ErrorCode.DUPLICATE_NICK_NAME, ErrorCode.NOT_VERIFY_EMAIL})
     @PostMapping("/register")
     public ResponseEntity<?> register(@RequestBody RegisterRequest registerRequest) {
         memberService.register(registerRequest);
 
-        return ResponseEntity.ok("회원가입에 성공하였습니다.");
+        return ResponseEntity.ok(ErrorCode.OK.getMessage());
     }
 
     @Operation(summary = "로그인 기능",
             description = "이메일, 비밀번호를 입력받아 로그인을 진행한다.",
             security = @SecurityRequirement(name = "Session 제외"))
+    @ApiResponse(responseCode = "200", description = "로그인 성공 시 닉네임이 반환된다.")
+    @ApiErrorCodeExamples({ErrorCode.UNAUTHORIZED})
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest, HttpServletRequest request, HttpServletResponse response) {
-        memberService.login(loginRequest, request, response);
-
-        return ResponseEntity.ok("로그인에 성공하였습니다.");
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest, HttpServletRequest request, HttpServletResponse response) {
+        return ResponseEntity.ok(memberService.login(loginRequest, request, response));
     }
 
     @Operation(summary = "이메일 인증 기능 - 인증번호 발급",
             description = "이메일을 입력받아 인증번호를 생성한다.",
             security = @SecurityRequirement(name = "Session 제외"))
+    @ApiErrorCodeExamples({ErrorCode.OK, ErrorCode.DUPLICATE_EMAIL})
     @PostMapping("/code")
     public ResponseEntity<?> sendVerificationCode(@RequestBody EmailRequest emailRequest) throws MessagingException {
         memberService.postCode(emailRequest.email());
 
-        return ResponseEntity.ok("인증번호가 발급되었습니다.");
+        return ResponseEntity.ok(ErrorCode.OK.getMessage());
     }
 
     @Operation(summary = "이메일 인증 기능 - 인증번호 확인",
             description = "이메일과 인증번호를 입력받아 인증번호를 확인한다.",
             security = @SecurityRequirement(name = "Session 제외"))
+    @ApiErrorCodeExamples({ErrorCode.OK, ErrorCode.DUPLICATE_EMAIL,ErrorCode.WRONG_VERIFICATION_CODE})
     @PostMapping("/verify")
     public ResponseEntity<?> verifyEmail(@RequestBody VerificationRequest verificationRequest) {
         memberService.verifyCode(verificationRequest.email(), verificationRequest.code());
 
-        return ResponseEntity.ok("이메일 인증에 성공하였습니다.");
+        return ResponseEntity.ok(ErrorCode.OK.getMessage());
     }
 
     @Operation(summary = "닉네임 중복 확인",
             description = "닉네임이 다른 사용자와 중복되는지 확인한다.",
             security = @SecurityRequirement(name = "Session 제외"))
+    @ApiErrorCodeExamples({ErrorCode.OK,ErrorCode.DUPLICATE_NICK_NAME})
     @PostMapping("/nick-name")
     public ResponseEntity<?> checkNickName(@RequestBody NickNameRequest nickNameRequest) {
         memberService.checkNickName(nickNameRequest.nickName());
 
-        return ResponseEntity.ok("사용 가능한 닉네임입니다.");
+        return ResponseEntity.ok(ErrorCode.OK.getMessage());
     }
 
     @Operation(summary = "이메일 중복 확인",
             description = "이메일이 다른 사용자와 중복되는지 확인한다.",
             security = @SecurityRequirement(name = "Session 제외"))
+    @ApiErrorCodeExamples({ErrorCode.OK, ErrorCode.DUPLICATE_EMAIL})
     @PostMapping("/email")
     public ResponseEntity<?> checkEmail(@RequestBody EmailRequest emailRequest) {
         memberService.checkEmail(emailRequest.email());
 
-        return ResponseEntity.ok("사용 가능한 이메일입니다.");
+        return ResponseEntity.ok(ErrorCode.OK.getMessage());
     }
 }

--- a/src/main/java/com/knu/algo_hive/auth/dto/LoginResponse.java
+++ b/src/main/java/com/knu/algo_hive/auth/dto/LoginResponse.java
@@ -1,0 +1,6 @@
+package com.knu.algo_hive.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LoginResponse(@Schema(description = "사용자 닉네임", example = "user1") String nickName) {
+}

--- a/src/main/java/com/knu/algo_hive/auth/service/CustomUserDetails.java
+++ b/src/main/java/com/knu/algo_hive/auth/service/CustomUserDetails.java
@@ -50,4 +50,8 @@ public class CustomUserDetails implements UserDetails {
     public String getUsername() {
         return member.getEmail();
     }
+
+    public Member getMember(){
+        return member;
+    }
 }

--- a/src/main/java/com/knu/algo_hive/auth/service/MailService.java
+++ b/src/main/java/com/knu/algo_hive/auth/service/MailService.java
@@ -6,6 +6,7 @@ import jakarta.mail.internet.MimeMessage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,7 +15,7 @@ public class MailService {
     @Value("${spring.mail.username}")
     private String senderEmail;
 
-    public MailService(JavaMailSender javaMailSender) {
+    public MailService(JavaMailSender javaMailSender){
         this.javaMailSender = javaMailSender;
     }
 
@@ -34,26 +35,57 @@ public class MailService {
 
     public MimeMessage verifyCodeTemplate(String email, String code) throws MessagingException {
         MimeMessage message = javaMailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
 
-        StringBuilder sb = new StringBuilder();
-
-        sb.append("<h2>안녕하세요.</h2>");
-        sb.append("<h2>Algo-Hive 입니다.</h2>");
-        sb.append("<br>");
-        sb.append("<p>아래 인증코드를 회원가입 페이지에 입력해주세요</p>");
-        sb.append("<br>");
-        sb.append("<br>");
-        sb.append("<div align='center' style='border:1px solid black'>");
-        sb.append("<h3 style='color:blue'>회원가입 인증코드 입니다</h3>");
-        sb.append("<div style='font-size:130%'>");
-        sb.append("<strong>").append(code).append("</strong></div><br/>");
-        sb.append("</div>");
-
-        String body = sb.toString();
-
-        message.setSubject("[Algo Hive] 이메일 인증번호");
-        message.setText(body, "UTF-8", "html");
+        helper.setTo(email);
+        helper.setSubject("[Algo Hive] 이메일 인증번호");
+        helper.setText(buildVerificationEmail(code), true);
 
         return message;
     }
+
+    public String buildVerificationEmail(String code) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<!doctype html>");
+        sb.append("<html>");
+        sb.append("<head>");
+        sb.append("<meta charset=\"utf-8\" />");
+        sb.append("<style>");
+        sb.append(".element { width: 250px; height: auto;}");
+        sb.append("* { -webkit-font-smoothing: antialiased; box-sizing: border-box; margin: 0; padding: 0; }");
+        sb.append("body { margin: 0; padding: 0; width: 100%; text-align: center; background-color: #f9f9f9; font-family: 'Pretendard-Regular', Arial, sans-serif; }");
+        sb.append("table { border-spacing: 0; margin: 0 auto; }");
+        sb.append(".email-container { max-width: 600px; width: 100%; background-color: #ffffff; border-radius: 8px; overflow: hidden; }");
+        sb.append(".header { background-color: #0076BF; padding: 20px; color: white; text-align: center; font-size: 24px; font-weight: bold; }");
+        sb.append(".content { padding: 30px; text-align: left; font-size: 16px; color: #333333; }");
+        sb.append(".code { display: block; margin: 20px 0; font-size: 28px; font-weight: bold; text-align: center; color: #555555; }");
+        sb.append(".footer { text-align: center; font-size: 12px; color: #888888; padding: 20px; }");
+        sb.append("</style>");
+        sb.append("</head>");
+        sb.append("<body>");
+        sb.append("<table role=\"presentation\" class=\"email-container\">");
+        sb.append("<td style=\"text-align: center; padding: 20px;\">");
+        sb.append("<img class=\"element\" src=\"https://velog.velcdn.com/images/2iedo/post/b8d1a533-9531-429e-81e8-9b4733c78996/image.png\" />");
+        sb.append("</td>");
+        sb.append("<tr>");
+        sb.append("<td class=\"header\">본인확인 인증 코드</td>");
+        sb.append("</tr>");
+        sb.append("<tr>");
+        sb.append("<td class=\"content\">");
+        sb.append("<p>안녕하세요,</p>");
+        sb.append("<p>본인 확인을 위해 아래 인증 코드를 입력해주세요:</p>");
+        sb.append("<span class=\"code\">").append(code).append("</span>");
+        sb.append("<p>인증 코드는 <strong>3분</strong> 동안만 유효합니다.</p>");
+        sb.append("</td>");
+        sb.append("</tr>");
+        sb.append("<tr>");
+        sb.append("<td class=\"footer\">이 이메일은 자동으로 발송되었습니다. 문의가 필요하시면 "+ senderEmail +"으로 연락해주세요.</td>");
+        sb.append("</tr>");
+        sb.append("</table>");
+        sb.append("</body>");
+        sb.append("</html>");
+
+        return sb.toString();
+    }
+
 }

--- a/src/main/java/com/knu/algo_hive/auth/service/MailService.java
+++ b/src/main/java/com/knu/algo_hive/auth/service/MailService.java
@@ -1,6 +1,7 @@
 package com.knu.algo_hive.auth.service;
 
 import com.knu.algo_hive.common.exception.ConflictException;
+import com.knu.algo_hive.common.exception.ErrorCode;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,8 +29,7 @@ public class MailService {
         try {
             javaMailSender.send(message); // 메일 발송
         } catch (MailException e) {
-            e.printStackTrace();
-            throw new ConflictException("메일 발송 중 오류가 발생했습니다.");
+            throw new ConflictException(ErrorCode.FAIL_SEND_EMAIL);
         }
     }
 

--- a/src/main/java/com/knu/algo_hive/auth/service/MemberService.java
+++ b/src/main/java/com/knu/algo_hive/auth/service/MemberService.java
@@ -7,6 +7,7 @@ import com.knu.algo_hive.auth.entity.Member;
 import com.knu.algo_hive.auth.repository.MemberRepository;
 import com.knu.algo_hive.common.exception.BadRequestException;
 import com.knu.algo_hive.common.exception.ConflictException;
+import com.knu.algo_hive.common.exception.ErrorCode;
 import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -47,7 +48,7 @@ public class MemberService {
         checkNickName(registerRequest.nickName());
 
         if (!Boolean.parseBoolean((String) redisTemplate.opsForHash().get(registerRequest.email(), "verified")))
-            throw new BadRequestException("이메일 인증을 하지 않았습니다.");
+            throw new BadRequestException(ErrorCode.NOT_VERIFY_EMAIL);
 
         Member member = new Member(registerRequest.nickName(),
                 registerRequest.email(),
@@ -75,12 +76,12 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public void checkEmail(String email) {
-        if (memberRepository.existsByEmail(email)) throw new ConflictException("중복된 이메일이 있습니다.");
+        if (memberRepository.existsByEmail(email)) throw new ConflictException(ErrorCode.DUPLICATE_EMAIL);
     }
 
     @Transactional(readOnly = true)
     public void checkNickName(String nickname) {
-        if (memberRepository.existsByNickName(nickname)) throw new ConflictException("중복된 닉네임이 있습니다.");
+        if (memberRepository.existsByNickName(nickname)) throw new ConflictException(ErrorCode.DUPLICATE_NICK_NAME);
     }
 
     public void postCode(String email) throws MessagingException {
@@ -106,6 +107,6 @@ public class MemberService {
             return;
         }
 
-        throw new BadRequestException("인증번호를 잘못 입력하였습니다.");
+        throw new BadRequestException(ErrorCode.WRONG_VERIFICATION_CODE);
     }
 }

--- a/src/main/java/com/knu/algo_hive/auth/service/MemberService.java
+++ b/src/main/java/com/knu/algo_hive/auth/service/MemberService.java
@@ -1,10 +1,12 @@
 package com.knu.algo_hive.auth.service;
 
 import com.knu.algo_hive.auth.dto.LoginRequest;
+import com.knu.algo_hive.auth.dto.LoginResponse;
 import com.knu.algo_hive.auth.dto.RegisterRequest;
 import com.knu.algo_hive.auth.entity.Member;
 import com.knu.algo_hive.auth.repository.MemberRepository;
 import com.knu.algo_hive.common.exception.BadRequestException;
+import com.knu.algo_hive.common.exception.ConflictException;
 import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -19,6 +21,7 @@ import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -38,7 +41,8 @@ public class MemberService {
     private final long ACCESS_THREE_MINUTES = 1000 * 60 * 3;
     private final long ACCESS_TEN_MINUTES = 1000 * 60 * 10;
 
-    public void register(RegisterRequest registerRequest) {
+    @Transactional
+    public LoginResponse register(RegisterRequest registerRequest) {
         checkEmail(registerRequest.email());
         checkNickName(registerRequest.nickName());
 
@@ -50,9 +54,11 @@ public class MemberService {
                 passwordEncoder.encode(registerRequest.password()));
 
         memberRepository.save(member);
+        return new LoginResponse(member.getNickName());
     }
 
-    public void login(LoginRequest loginRequest, HttpServletRequest request, HttpServletResponse response) {
+    @Transactional(readOnly = true)
+    public LoginResponse login(LoginRequest loginRequest, HttpServletRequest request, HttpServletResponse response) {
         UsernamePasswordAuthenticationToken authenticationToken =
                 new UsernamePasswordAuthenticationToken(loginRequest.email(), loginRequest.password());
 
@@ -61,14 +67,21 @@ public class MemberService {
         SecurityContext context = this.securityContextHolderStrategy.createEmptyContext();
         context.setAuthentication(authentication);
         securityContextRepository.saveContext(context, request, response);
+
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        Member member = userDetails.getMember();
+
+        return new LoginResponse(member.getNickName());
     }
 
+    @Transactional(readOnly = true)
     public void checkEmail(String email) {
-        if (memberRepository.existsByEmail(email)) throw new BadRequestException("중복된 이메일이 있습니다.");
+        if (memberRepository.existsByEmail(email)) throw new ConflictException("중복된 이메일이 있습니다.");
     }
 
+    @Transactional(readOnly = true)
     public void checkNickName(String nickname) {
-        if (memberRepository.existsByNickName(nickname)) throw new BadRequestException("중복된 닉네임이 있습니다.");
+        if (memberRepository.existsByNickName(nickname)) throw new ConflictException("중복된 닉네임이 있습니다.");
     }
 
     public void postCode(String email) throws MessagingException {

--- a/src/main/java/com/knu/algo_hive/auth/service/MemberService.java
+++ b/src/main/java/com/knu/algo_hive/auth/service/MemberService.java
@@ -42,7 +42,7 @@ public class MemberService {
     private final long ACCESS_TEN_MINUTES = 1000 * 60 * 10;
 
     @Transactional
-    public LoginResponse register(RegisterRequest registerRequest) {
+    public void register(RegisterRequest registerRequest) {
         checkEmail(registerRequest.email());
         checkNickName(registerRequest.nickName());
 
@@ -54,7 +54,6 @@ public class MemberService {
                 passwordEncoder.encode(registerRequest.password()));
 
         memberRepository.save(member);
-        return new LoginResponse(member.getNickName());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/knu/algo_hive/common/annotation/ApiErrorCodeExample.java
+++ b/src/main/java/com/knu/algo_hive/common/annotation/ApiErrorCodeExample.java
@@ -1,0 +1,15 @@
+package com.knu.algo_hive.common.annotation;
+
+import com.knu.algo_hive.common.exception.ErrorCode;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExample {
+
+    ErrorCode value();
+}

--- a/src/main/java/com/knu/algo_hive/common/annotation/ApiErrorCodeExamples.java
+++ b/src/main/java/com/knu/algo_hive/common/annotation/ApiErrorCodeExamples.java
@@ -1,0 +1,15 @@
+package com.knu.algo_hive.common.annotation;
+
+import com.knu.algo_hive.common.exception.ErrorCode;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExamples {
+
+    ErrorCode[] value();
+}

--- a/src/main/java/com/knu/algo_hive/common/config/SwaggerConfig.java
+++ b/src/main/java/com/knu/algo_hive/common/config/SwaggerConfig.java
@@ -1,10 +1,28 @@
 package com.knu.algo_hive.common.config;
 
+import com.knu.algo_hive.common.annotation.ApiErrorCodeExample;
+import com.knu.algo_hive.common.annotation.ApiErrorCodeExamples;
+import com.knu.algo_hive.common.exception.ErrorCode;
+import com.knu.algo_hive.common.exception.ErrorResponseDto;
+import com.knu.algo_hive.common.exception.ExampleHolder;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Configuration
 public class SwaggerConfig {
@@ -21,5 +39,93 @@ public class SwaggerConfig {
                 .title("Algo-Hive Team Toy Project 명세서")
                 .description("[Team Notion 바로가기](https://www.notion.so/1602c5ccabe480a4821bdbf72f003c57)")
                 .version("0.0.1");
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            ApiErrorCodeExamples apiErrorCodeExamples = handlerMethod.getMethodAnnotation(
+                    ApiErrorCodeExamples.class);
+
+            if (apiErrorCodeExamples != null) {
+                generateErrorCodeResponseExample(operation, apiErrorCodeExamples.value());
+            } else {
+                ApiErrorCodeExample apiErrorCodeExample = handlerMethod.getMethodAnnotation(
+                        ApiErrorCodeExample.class);
+
+                if (apiErrorCodeExample != null) {
+                    generateErrorCodeResponseExample(operation, apiErrorCodeExample.value());
+                }
+            }
+
+            return operation;
+        };
+    }
+
+    private void generateErrorCodeResponseExample(Operation operation, ErrorCode[] errorCodes) {
+        ApiResponses responses = operation.getResponses();
+
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders = Arrays.stream(errorCodes)
+                .map(
+                        errorCode -> ExampleHolder.builder()
+                                .holder(getSwaggerExample(errorCode))
+                                .code(errorCode.getHttpStatus().value())
+                                .name(errorCode.name())
+                                .build()
+                )
+                .collect(Collectors.groupingBy(ExampleHolder::getCode));
+
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private void generateErrorCodeResponseExample(Operation operation, ErrorCode errorCode) {
+        ApiResponses responses = operation.getResponses();
+
+        ExampleHolder exampleHolder = ExampleHolder.builder()
+                .holder(getSwaggerExample(errorCode))
+                .name(errorCode.name())
+                .code(errorCode.getHttpStatus().value())
+                .build();
+        addExamplesToResponses(responses, exampleHolder);
+    }
+
+    private Example getSwaggerExample(ErrorCode errorCode) {
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(errorCode);
+        Example example = new Example();
+        example.setValue(errorResponseDto);
+
+        return example;
+    }
+
+    private void addExamplesToResponses(ApiResponses responses,
+                                        Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach(
+                (status, v) -> {
+                    Content content = new Content();
+                    MediaType mediaType = new MediaType();
+                    ApiResponse apiResponse = new ApiResponse();
+
+                    v.forEach(
+                            exampleHolder -> mediaType.addExamples(
+                                    exampleHolder.getName(),
+                                    exampleHolder.getHolder()
+                            )
+                    );
+                    content.addMediaType("application/json", mediaType);
+                    apiResponse.setContent(content);
+                    responses.addApiResponse(String.valueOf(status), apiResponse);
+                }
+        );
+    }
+
+    private void addExamplesToResponses(ApiResponses responses, ExampleHolder exampleHolder) {
+        Content content = new Content();
+        MediaType mediaType = new MediaType();
+        ApiResponse apiResponse = new ApiResponse();
+
+        mediaType.addExamples(exampleHolder.getName(), exampleHolder.getHolder());
+        content.addMediaType("application/json", mediaType);
+        apiResponse.content(content);
+        responses.addApiResponse(String.valueOf(exampleHolder.getCode()), apiResponse);
     }
 }

--- a/src/main/java/com/knu/algo_hive/common/exception/BadRequestException.java
+++ b/src/main/java/com/knu/algo_hive/common/exception/BadRequestException.java
@@ -1,8 +1,9 @@
 package com.knu.algo_hive.common.exception;
 
 public class BadRequestException extends RuntimeException {
-
+    ErrorCode errorCode;
     public BadRequestException(String message) {
         super(message);
     }
+    public BadRequestException(ErrorCode errorcode){this.errorCode = errorcode;}
 }

--- a/src/main/java/com/knu/algo_hive/common/exception/ConflictException.java
+++ b/src/main/java/com/knu/algo_hive/common/exception/ConflictException.java
@@ -1,8 +1,9 @@
 package com.knu.algo_hive.common.exception;
 
 public class ConflictException extends RuntimeException {
-
+    ErrorCode errorCode;
     public ConflictException(String message) {
         super(message);
     }
+    public ConflictException(ErrorCode errorcode){this.errorCode = errorcode;}
 }

--- a/src/main/java/com/knu/algo_hive/common/exception/ErrorCode.java
+++ b/src/main/java/com/knu/algo_hive/common/exception/ErrorCode.java
@@ -1,0 +1,45 @@
+package com.knu.algo_hive.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    //OK
+    OK(HttpStatus.OK, "성공했습니다."),
+
+    //Auth
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "중복된 이메일이 있습니다."),
+    DUPLICATE_NICK_NAME(HttpStatus.CONFLICT, "중복된 닉네임이 있습니다."),
+    NOT_VERIFY_EMAIL(HttpStatus.BAD_REQUEST, "이메일 인증을 하지 않았습니다."),
+    WRONG_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증 번호를 잘못 입력하였습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인 시 입력한 정보가 틀렸거나, 로그인을 하지 않았습니다."),
+
+    //Mail
+    FAIL_SEND_EMAIL(HttpStatus.CONFLICT, "이메일 전송 중 에러가 발생하였습니다."),
+
+    //Chat
+    ROOM_NAME_NOT_EXISTS(HttpStatus.NOT_FOUND, "해당 roomName은 존재하지 않습니다."),
+    ROOM_NOT_EXISTS(HttpStatus.NOT_FOUND, "roomName에 해당하는 방이 없습니다."),
+
+    //Post
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public String getMessage(Throwable throwable) {
+        return this.getMessage(this.getMessage(this.getMessage() + " - " + throwable.getMessage()));
+    }
+
+    public String getMessage(String message) {
+        return Optional.ofNullable(message)
+                .filter(Predicate.not(String::isBlank))
+                .orElse(this.getMessage());
+    }
+}

--- a/src/main/java/com/knu/algo_hive/common/exception/ErrorResponseDto.java
+++ b/src/main/java/com/knu/algo_hive/common/exception/ErrorResponseDto.java
@@ -1,0 +1,14 @@
+package com.knu.algo_hive.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponseDto {
+    private String code;
+    private String message;
+
+    public ErrorResponseDto(ErrorCode errorCode) {
+        this.code = errorCode.getHttpStatus().toString();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/knu/algo_hive/common/exception/ExampleHolder.java
+++ b/src/main/java/com/knu/algo_hive/common/exception/ExampleHolder.java
@@ -1,0 +1,14 @@
+package com.knu.algo_hive.common.exception;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+
+    private Example holder;
+    private String name;
+    private int code;
+}

--- a/src/main/java/com/knu/algo_hive/common/exception/ForbiddenException.java
+++ b/src/main/java/com/knu/algo_hive/common/exception/ForbiddenException.java
@@ -1,8 +1,9 @@
 package com.knu.algo_hive.common.exception;
 
 public class ForbiddenException extends RuntimeException {
-
+    ErrorCode errorCode;
     public ForbiddenException(String message) {
         super(message);
     }
+    public ForbiddenException(ErrorCode errorcode){this.errorCode = errorcode;}
 }

--- a/src/main/java/com/knu/algo_hive/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/knu/algo_hive/common/exception/GlobalExceptionHandler.java
@@ -11,41 +11,41 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ForbiddenException.class)
     public ResponseEntity<ProblemDetail> handleForbiddenException(ForbiddenException e) {
-
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, e.getMessage());
+        ErrorCode errorCode = e.errorCode;
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, errorCode.getMessage());
         problemDetail.setTitle("Forbidden");
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(problemDetail);
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(problemDetail);
     }
 
     @ExceptionHandler(ConflictException.class)
     public ResponseEntity<ProblemDetail> handleConflictException(ConflictException e) {
-
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, e.getMessage());
+        ErrorCode errorCode = e.errorCode;
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, errorCode.getMessage());
         problemDetail.setTitle("Conflict");
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(problemDetail);
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(problemDetail);
     }
 
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ProblemDetail> handleNotFoundException(NotFoundException e) {
-
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+        ErrorCode errorCode = e.errorCode;
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, errorCode.getMessage());
         problemDetail.setTitle("Not Found");
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problemDetail);
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(problemDetail);
     }
 
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<ProblemDetail> handleUnauthorizedException(UnauthorizedException e) {
-
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, e.getMessage());
+        ErrorCode errorCode = e.errorCode;
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, errorCode.getMessage());
         problemDetail.setTitle("Unauthorized");
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(problemDetail);
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(problemDetail);
     }
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<ProblemDetail> handleBadRequestException(BadRequestException e) {
-
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+        ErrorCode errorCode = e.errorCode;
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, errorCode.getMessage());
         problemDetail.setTitle("Bad Request");
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(problemDetail);
     }
 }

--- a/src/main/java/com/knu/algo_hive/common/exception/NotFoundException.java
+++ b/src/main/java/com/knu/algo_hive/common/exception/NotFoundException.java
@@ -1,8 +1,9 @@
 package com.knu.algo_hive.common.exception;
 
 public class NotFoundException extends RuntimeException {
-
+    ErrorCode errorCode;
     public NotFoundException(String message) {
         super(message);
     }
+    public NotFoundException(ErrorCode errorcode){this.errorCode = errorcode;}
 }

--- a/src/main/java/com/knu/algo_hive/common/exception/UnauthorizedException.java
+++ b/src/main/java/com/knu/algo_hive/common/exception/UnauthorizedException.java
@@ -2,7 +2,9 @@ package com.knu.algo_hive.common.exception;
 
 public class UnauthorizedException extends RuntimeException {
 
+    ErrorCode errorCode;
     public UnauthorizedException(String message) {
         super(message);
     }
+    public UnauthorizedException(ErrorCode errorcode){this.errorCode = errorcode;}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #43 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)

1. 이메일 인증 메일 형식 수정
![image](https://github.com/user-attachments/assets/d104d29d-321b-45ab-b6b2-f87d827513ad)

기존의 이메일 형식보다 좀 더 깔끔하게 수정했습니다.

2. 데이터베이스 접근 시 transactional 어노테이션 추가

3. api 문서 수정
![image](https://github.com/user-attachments/assets/f46fde4f-ee59-4e6f-bf69-cc4626c45d88)

- 기존의 ApiResponse 어노테이션에는 에러 코드에 대한 에러 메시지가 나오지 않는 문제점이 있습니다. 이 이유는

> 1. 각 예외 발생 시마다 Exception의 인자로 메시를 그때그때 입력하는 문제
>2. Swagger에서 각 api마다 발생할 수 있는 Exception을 탐지하지 못하는 문제
>3. GlobalExceptionHandler에 @ApiResponse를 붙일 경우 모든 api에 모든 에러코드가 나오는 문제

이러한 문제점을 해결하기 위해서 
> 1. 상태코드와 메시지를 Enum 형태의 ErrorCode를 선언하여 통일 => SwaggerConfig에 예시를 추가하는 로직 추가
>2.  커스텀 어노테이션인 @ApiErrorCodeExample 을 선언 => 각 api마다 발생할 수 있는 에러 코드는 개발자가 직접 @ApiErrorCodeExamples에 추가, ErrorResponseDto 및 ExampleHolder을 통해 swagger에 예시 추가

현재 ErrorCode Enum에는 제가 서비스 및 컨트롤러 레이어 확인하면서 어느정도 추가해놨는데, 각 도메인별로 필요하신 부분 추가하시면 됩니다. api 명세서 작성하는 부분에서 어려운 점 있으시면 알려주세요!

참고자료 : https://leeeeeyeon-dev.tistory.com/92#google_vignette

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 현재 Swagger의 response에 있는 예시(ErrorResponseDto)와 실제 api 실행 시 resposne(body에 ProblemDetail)에 차이점이 있습니다.  실제 실행하는 것처럼 수정하는 것보다 가독성이 더 좋은 것 같아서 그대로 놔누었는데, 수정하는게 좋을 것 같으면 코멘트 남겨주시면 감사하겠습니다.

## ⏰ 현재 버그

## ✏ Git Close

> close #43 
