### PR TITLE
Feat: 채팅방별 접속자 수 조회가능 구현

### DIFF
--- a/src/main/java/com/knu/algo_hive/chat/rabbitmq/UserStatusConsumer.java
+++ b/src/main/java/com/knu/algo_hive/chat/rabbitmq/UserStatusConsumer.java
@@ -37,7 +37,11 @@ public class UserStatusConsumer {
             redisTemplate.opsForHash().increment(REDIS_ROOM_COUNT_KEY, roomName, 1);
         } else {
             redisTemplate.opsForSet().remove(REDIS_USER_KEY, user);
-            redisTemplate.opsForHash().increment(REDIS_ROOM_COUNT_KEY, roomName, -1);
+            Long count = redisTemplate.opsForHash().increment(REDIS_ROOM_COUNT_KEY, roomName, -1);
+
+            if (count <= 0) {
+                redisTemplate.opsForHash().delete(REDIS_ROOM_COUNT_KEY, roomName);
+            }
         }
 
         Set<Object> rawUsers = redisTemplate.opsForSet().members(REDIS_USER_KEY);

--- a/src/main/java/com/knu/algo_hive/chat/rabbitmq/UserStatusProducer.java
+++ b/src/main/java/com/knu/algo_hive/chat/rabbitmq/UserStatusProducer.java
@@ -11,7 +11,7 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 @Service
 public class UserStatusProducer {
 
-    private static final String USER_QUEUE_NAME = "allUserQueue";
+    private static final String USER_QUEUE_NAME = "chatUsersQueue";
 
     private final RabbitTemplate rabbitTemplate;
 

--- a/src/main/java/com/knu/algo_hive/common/config/RabbitConfig.java
+++ b/src/main/java/com/knu/algo_hive/common/config/RabbitConfig.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration;
 public class RabbitConfig {
 
     private static final String MESSAGE_QUEUE_NAME = "algoQueue";
-    private static final String USER_QUEUE_NAME = "allUserQueue";
+    private static final String USER_QUEUE_NAME = "chatUsersQueue";
 
     private static final boolean DURABLE = true;
     private static final int CONNECTION_TIMEOUT = 10000;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#48 

## 📝 작업 내용

- 새로운 구독 경로 추가 및 redis에 map 형태로 채팅방별 인원 저장
- 채팅방별 인원이 0명일 시 redis에서 삭제하는 기능 추가

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f7879488-66cc-433f-8cdf-c4198a049507)
![image](https://github.com/user-attachments/assets/7b95fd4b-8335-4f9d-9eac-7c32a0cd7dcf)

## 💬 리뷰 요구사항(선택)
서버 업로드 후 확실하게 확인 가능합니다!

## ⏰ 현재 버그
서버 업로드 후 확실하게 확인 가능합니다!
로컬에서는 이상 없습니다 :)

## ✏ Git Close

close #48 
